### PR TITLE
feat: enhance analytics page with pitcher profiles and streamline sim…

### DIFF
--- a/web/src/app/analytics/page.tsx
+++ b/web/src/app/analytics/page.tsx
@@ -17,6 +17,7 @@ import type {
 import { ProbabilityBar } from "@/features/analytics/components/ProbabilityBar";
 import { ScoreCard } from "@/features/analytics/components/ScoreCard";
 import { PABreakdown } from "@/features/analytics/components/PABreakdown";
+import { PitcherProfile } from "@/features/analytics/components/PitcherProfile";
 import { LineupBuilder } from "@/features/analytics/components/LineupBuilder";
 import { AuthGate } from "@/components/auth/AuthGate";
 
@@ -26,8 +27,6 @@ const EMPTY_LINEUP: LineupSlot[] = Array.from({ length: 9 }, () => ({
   external_ref: "",
   name: "",
 }));
-const DEFAULT_STARTER_INNINGS = 6.0;
-
 function autoFillLineup(batters: RosterBatter[]): LineupSlot[] {
   return batters.slice(0, 9).map((b) => ({
     external_ref: b.external_ref,
@@ -37,7 +36,7 @@ function autoFillLineup(batters: RosterBatter[]): LineupSlot[] {
 
 function autoFillStarter(pitchers: RosterPitcher[]): PitcherSlot | null {
   const p = pitchers[0];
-  return p ? { external_ref: p.external_ref, name: p.name } : null;
+  return p ? { external_ref: p.external_ref, name: p.name, avg_ip: p.avg_ip } : null;
 }
 
 export default function AnalyticsPage() {
@@ -60,7 +59,6 @@ export default function AnalyticsPage() {
   const [awayLineup, setAwayLineup] = useState<LineupSlot[]>([...EMPTY_LINEUP]);
   const [homeStarter, setHomeStarter] = useState<PitcherSlot | null>(null);
   const [awayStarter, setAwayStarter] = useState<PitcherSlot | null>(null);
-  const [starterInnings, setStarterInnings] = useState(DEFAULT_STARTER_INNINGS);
 
   // Results
   const [result, setResult] = useState<SimulatorResult | null>(null);
@@ -204,7 +202,8 @@ export default function AnalyticsPage() {
         away_lineup: awayLineup,
         home_starter: homeStarter!,
         away_starter: awayStarter!,
-        starter_innings: starterInnings,
+        starter_innings: 6,
+        exclude_playoffs: true,
       });
       setResult(data);
     } catch {
@@ -220,7 +219,6 @@ export default function AnalyticsPage() {
     awayLineup,
     homeStarter,
     awayStarter,
-    starterInnings,
   ]);
 
   // ─── Derived display names ────────────────────────────────
@@ -333,27 +331,6 @@ export default function AnalyticsPage() {
                 loading={homeRosterLoading}
               />
             )}
-          </div>
-        )}
-
-        {/* ── Starter Innings ───────────────────────────── */}
-        {homeAbbr && awayAbbr && (
-          <div className="flex items-center gap-3">
-            <label className="text-xs font-medium text-neutral-500 uppercase tracking-wider shrink-0">
-              Starter Innings
-            </label>
-            <input
-              type="range"
-              min={4}
-              max={9}
-              step={0.5}
-              value={starterInnings}
-              onChange={(e) => setStarterInnings(parseFloat(e.target.value))}
-              className="flex-1 accent-blue-500"
-            />
-            <span className="text-sm font-medium text-neutral-300 tabular-nums w-8 text-right">
-              {starterInnings.toFixed(1)}
-            </span>
           </div>
         )}
 
@@ -506,6 +483,31 @@ export default function AnalyticsPage() {
                     label={homeName}
                     probs={result.home_pa_probabilities}
                   />
+                </div>
+              </div>
+            )}
+
+            {/* Pitching Analytics */}
+            {(result.profile_meta?.away_pitcher || result.profile_meta?.home_pitcher) && (
+              <div className="space-y-3">
+                <h4 className="text-xs font-medium text-neutral-500 uppercase tracking-wider">
+                  Pitching Profiles
+                </h4>
+                <div className="grid grid-cols-2 gap-3">
+                  {result.profile_meta?.away_pitcher && (
+                    <PitcherProfile
+                      label={awayName}
+                      info={result.profile_meta.away_pitcher}
+                      bullpen={result.profile_meta.away_bullpen}
+                    />
+                  )}
+                  {result.profile_meta?.home_pitcher && (
+                    <PitcherProfile
+                      label={homeName}
+                      info={result.profile_meta.home_pitcher}
+                      bullpen={result.profile_meta.home_bullpen}
+                    />
+                  )}
                 </div>
               </div>
             )}

--- a/web/src/features/analytics/components/LineupBuilder.tsx
+++ b/web/src/features/analytics/components/LineupBuilder.tsx
@@ -76,14 +76,14 @@ export function LineupBuilder({
           value={starter?.external_ref ?? ""}
           onChange={(e) => {
             const p = pitchers.find((p) => p.external_ref === e.target.value);
-            onStarterChange(p ? { external_ref: p.external_ref, name: p.name } : null);
+            onStarterChange(p ? { external_ref: p.external_ref, name: p.name, avg_ip: p.avg_ip } : null);
           }}
           className="w-full text-xs rounded-md px-2 py-1.5 bg-neutral-900 text-neutral-200 border border-neutral-800 outline-none"
         >
           <option value="">Select pitcher</option>
           {pitchers.map((p) => (
             <option key={p.external_ref} value={p.external_ref}>
-              {p.name} ({p.games}G, {p.avg_ip.toFixed(1)} IP/G)
+              {p.name}
             </option>
           ))}
         </select>
@@ -118,7 +118,7 @@ export function LineupBuilder({
                       value={b.external_ref}
                       disabled={taken}
                     >
-                      {b.name} ({b.games_played}G){taken ? " (in lineup)" : ""}
+                      {b.name}{taken ? " (in lineup)" : ""}
                     </option>
                   );
                 })}

--- a/web/src/features/analytics/components/PABreakdown.tsx
+++ b/web/src/features/analytics/components/PABreakdown.tsx
@@ -20,7 +20,7 @@ export function PABreakdown({ label, probs }: PABreakdownProps) {
       <span className="text-xs font-medium text-neutral-400">{label}</span>
       <div className="space-y-1.5">
         {EVENT_LABELS.map(({ key, label: eventLabel }) => {
-          const val = probs[key] ?? 0;
+          const val = probs[`${key}_probability`] ?? probs[key] ?? 0;
           const pct = (val * 100).toFixed(1);
           return (
             <div key={key} className="flex items-center justify-between text-xs">

--- a/web/src/features/analytics/components/PitcherProfile.tsx
+++ b/web/src/features/analytics/components/PitcherProfile.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import type { PitcherProfileInfo } from "../types";
+
+const METRICS: { key: string; label: string }[] = [
+  { key: "strikeout", label: "K Rate" },
+  { key: "walk", label: "BB Rate" },
+  { key: "contact_suppression", label: "Contact Supp." },
+  { key: "power_suppression", label: "Power Supp." },
+];
+
+function fmtPct(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+interface PitcherProfileProps {
+  label: string;
+  info: PitcherProfileInfo;
+  bullpen?: Record<string, number> | null;
+}
+
+export function PitcherProfile({ label, info, bullpen }: PitcherProfileProps) {
+  const hasProfile = info.raw_profile || info.adjusted_profile;
+  const profile = info.adjusted_profile ?? info.raw_profile;
+
+  return (
+    <div className="card px-3 py-3 space-y-2">
+      <div className="flex items-baseline justify-between">
+        <span className="text-xs font-medium text-neutral-400">{label}</span>
+        {info.avg_ip != null && (
+          <span className="text-[11px] text-neutral-600 tabular-nums">
+            {info.avg_ip.toFixed(1)} avg IP/G
+          </span>
+        )}
+      </div>
+
+      {info.is_regressed && (
+        <p className="text-[11px] text-amber-500/80">
+          Regressed toward league avg
+        </p>
+      )}
+
+      {!hasProfile && (
+        <p className="text-[11px] text-neutral-600">League-average defaults</p>
+      )}
+
+      {hasProfile && profile && (
+        <div className="space-y-1">
+          {METRICS.map(({ key, label: metricLabel }) => {
+            const raw = info.raw_profile?.[key];
+            const adj = info.adjusted_profile?.[key];
+            const display = adj ?? raw;
+
+            return (
+              <div key={key} className="flex items-center justify-between text-xs">
+                <span className="text-neutral-500 w-24 shrink-0">{metricLabel}</span>
+                {info.is_regressed && raw != null && adj != null ? (
+                  <span className="text-neutral-400 tabular-nums">
+                    <span className="text-neutral-600">{fmtPct(raw)}</span>
+                    <span className="text-neutral-600 mx-1">&rarr;</span>
+                    {fmtPct(adj)}
+                  </span>
+                ) : (
+                  <span className="text-neutral-400 tabular-nums">
+                    {display != null ? fmtPct(display) : "—"}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {bullpen && Object.keys(bullpen).length > 0 && (
+        <div className="pt-1.5 border-t border-neutral-800/50 space-y-1">
+          <span className="text-[11px] text-neutral-600">Bullpen</span>
+          {METRICS.map(({ key, label: metricLabel }) => {
+            const val = bullpen[key];
+            return val != null ? (
+              <div key={key} className="flex items-center justify-between text-xs">
+                <span className="text-neutral-500 w-24 shrink-0">{metricLabel}</span>
+                <span className="text-neutral-400 tabular-nums">{fmtPct(val)}</span>
+              </div>
+            ) : null;
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/analytics/types.ts
+++ b/web/src/features/analytics/types.ts
@@ -31,7 +31,11 @@ export interface LineupSlot {
   name: string;
 }
 
-export type PitcherSlot = LineupSlot;
+export interface PitcherSlot {
+  external_ref: string;
+  name: string;
+  avg_ip?: number;
+}
 
 export interface SimulationRequest {
   sport: string;
@@ -45,6 +49,7 @@ export interface SimulationRequest {
   home_starter?: PitcherSlot;
   away_starter?: PitcherSlot;
   starter_innings?: number;
+  exclude_playoffs?: boolean;
 }
 
 export interface MostCommonScore {
@@ -79,7 +84,19 @@ export interface SimulatorResult {
     rolling_window?: number;
     model_win_probability?: number;
     lineup_mode?: LineupModeInfo;
+    home_pitcher?: PitcherProfileInfo;
+    away_pitcher?: PitcherProfileInfo;
+    home_bullpen?: Record<string, number>;
+    away_bullpen?: Record<string, number>;
   };
   home_pa_probabilities?: Record<string, number>;
   away_pa_probabilities?: Record<string, number>;
+}
+
+export interface PitcherProfileInfo {
+  name: string | null;
+  avg_ip: number | null;
+  raw_profile: Record<string, number> | null;
+  adjusted_profile: Record<string, number> | null;
+  is_regressed: boolean;
 }


### PR DESCRIPTION
This pull request enhances the analytics page by adding detailed pitching analytics and simplifying the handling of pitcher data. The main improvements include introducing a new `PitcherProfile` component to display pitcher and bullpen metrics, updating types to support richer pitcher information, and removing the adjustable starter innings UI in favor of a fixed value. Additionally, the plate appearance breakdown now better handles probability keys.

**Pitching analytics improvements:**

* Added a new `PitcherProfile` component to display detailed pitching metrics and bullpen information for both home and away starters on the analytics results page. (`web/src/features/analytics/components/PitcherProfile.tsx`, `web/src/app/analytics/page.tsx`) [[1]](diffhunk://#diff-7989ef484f04da8f556090f820447c50c2277a13ca2ae22c1c27abcbc346aa0bR1-R90) [[2]](diffhunk://#diff-a3aace1a228a0df74f88a772f05cbd097f2b5f1b2aa037ca5e680bacc8c7d184R20) [[3]](diffhunk://#diff-a3aace1a228a0df74f88a772f05cbd097f2b5f1b2aa037ca5e680bacc8c7d184R490-R514)
* Updated the `PitcherSlot` type to an interface with an optional `avg_ip` field, and extended the simulation result metadata to include detailed pitcher and bullpen profiles. (`web/src/features/analytics/types.ts`) [[1]](diffhunk://#diff-082b83fb5c8b3291ab8e9ca60a3df06d078b2621c22af2eda4d9e20b7b409dd4L34-R38) [[2]](diffhunk://#diff-082b83fb5c8b3291ab8e9ca60a3df06d078b2621c22af2eda4d9e20b7b409dd4R87-R102)

**UI and data handling simplifications:**

* Removed the adjustable "Starter Innings" slider from the UI and now always uses a fixed value of 6 innings for simulations. (`web/src/app/analytics/page.tsx`) [[1]](diffhunk://#diff-a3aace1a228a0df74f88a772f05cbd097f2b5f1b2aa037ca5e680bacc8c7d184L29-L30) [[2]](diffhunk://#diff-a3aace1a228a0df74f88a772f05cbd097f2b5f1b2aa037ca5e680bacc8c7d184L63) [[3]](diffhunk://#diff-a3aace1a228a0df74f88a772f05cbd097f2b5f1b2aa037ca5e680bacc8c7d184L207-R206) [[4]](diffhunk://#diff-a3aace1a228a0df74f88a772f05cbd097f2b5f1b2aa037ca5e680bacc8c7d184L223) [[5]](diffhunk://#diff-a3aace1a228a0df74f88a772f05cbd097f2b5f1b2aa037ca5e680bacc8c7d184L339-L359)
* Updated the `LineupBuilder` to pass and display the `avg_ip` value for selected pitchers, but simplified the dropdown to only show pitcher names. (`web/src/features/analytics/components/LineupBuilder.tsx`)

**Other improvements:**

* Improved the plate appearance breakdown to handle both legacy and new probability key formats. (`web/src/features/analytics/components/PABreakdown.tsx`)