### PR TITLE
fix(catchup): full names, directional fouls, runner fallback, retro restyle

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "scroll-down-mlb",
       "version": "0.1.0",
       "dependencies": {
-        "next": "16.2.4",
+        "next": "16.2.6",
         "react": "19.2.5",
         "react-dom": "19.2.5",
         "zustand": "^5.0.12"
@@ -25,7 +25,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.5",
         "eslint": "~9.28",
-        "eslint-config-next": "16.2.4",
+        "eslint-config-next": "16.2.6",
         "fake-indexeddb": "^6.2.5",
         "jsdom": "^29.1.1",
         "tailwindcss": "^4",
@@ -1379,15 +1379,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.4.tgz",
-      "integrity": "sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.6.tgz",
+      "integrity": "sha512-Z8l6o4JWKUl755x4R+wogD86KPeU+Ckw4K+SYG4kHeOJtRenDeK+OSbGcqZpDtbwn9DsJVdir2UxmwXuinUbUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1395,9 +1395,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -1411,9 +1411,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -1427,9 +1427,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -1443,9 +1443,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -1459,9 +1459,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -1475,9 +1475,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -1491,9 +1491,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -1507,9 +1507,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -4010,13 +4010,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.4.tgz",
-      "integrity": "sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.6.tgz",
+      "integrity": "sha512-z2ELYSkyrrJ6cuunTU8vhsT/RpouPkjaSah06nVW6Rg2Hpg0Vs8s497/e5s8G8qtdp4ccsiovz5P1rv+5VSW2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.4",
+        "@next/eslint-plugin-next": "16.2.6",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -6456,12 +6456,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -6475,14 +6475,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -17,7 +17,7 @@
     "test:unit:coverage": "vitest run --coverage --passWithNoTests"
   },
   "dependencies": {
-    "next": "16.2.4",
+    "next": "16.2.6",
     "react": "19.2.5",
     "react-dom": "19.2.5",
     "zustand": "^5.0.12"
@@ -34,7 +34,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "~9.28",
-    "eslint-config-next": "16.2.4",
+    "eslint-config-next": "16.2.6",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^29.1.1",
     "tailwindcss": "^4",

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -539,11 +539,12 @@ body {
   font-size: 0.625rem;
 }
 .catchup-card-inning {
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
+  font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
+  font-size: 0.9375rem;
+  font-weight: 400;
+  letter-spacing: 0.14em;
   color: var(--lev-amber, #fde68a);
-  text-shadow: 0 0 var(--lev-glow-radius, 8px) rgba(251, 191, 36, 0.55);
+  text-shadow: 0 0 var(--lev-glow-radius, 8px) rgba(251, 191, 36, 0.6);
   transition: color 600ms ease, text-shadow 600ms ease;
 }
 
@@ -564,40 +565,48 @@ body {
 }
 .catchup-card-batter,
 .catchup-card-pitcher {
-  font-size: 0.9375rem;
-  font-weight: 700;
-  letter-spacing: 0.04em;
+  /* Retro CRT-readout typography. Wider letter-spacing makes the pixel
+     font breathe in small caps. flex-shrink lets long full names trade
+     space rather than blow out the row. */
+  font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
+  font-size: 1.125rem;
+  font-weight: 400;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   min-width: 0;
+  flex: 0 1 auto;
 }
 .catchup-card-batter {
-  color: #ffffff;
-  text-shadow: 0 0 6px rgba(251, 191, 36, 0.35);
+  color: #fff7c4;
+  text-shadow:
+    0 0 4px rgba(255, 207, 64, 0.85),
+    0 0 10px rgba(251, 191, 36, 0.55);
 }
 .catchup-card-pitcher {
-  color: rgba(255, 230, 180, 0.92);
+  color: rgba(255, 220, 140, 0.95);
+  text-shadow: 0 0 6px rgba(251, 191, 36, 0.45);
 }
 .catchup-card-vs {
   flex: 0 0 auto;
-  font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
-  font-size: 0.625rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  color: rgba(255, 220, 150, 0.42);
+  font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
+  font-size: 0.75rem;
+  font-weight: 400;
+  letter-spacing: 0.22em;
+  color: rgba(255, 220, 150, 0.55);
   text-transform: uppercase;
 }
 .catchup-card-count {
   flex: 0 0 auto;
-  font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
+  font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
   font-variant-numeric: tabular-nums;
-  font-size: 0.75rem;
-  font-weight: 700;
-  letter-spacing: 0.10em;
-  color: rgba(253, 230, 138, 0.85);
-  text-shadow: 0 0 4px rgba(251, 191, 36, 0.45);
+  font-size: 1rem;
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  color: #fde68a;
+  text-shadow: 0 0 4px rgba(251, 191, 36, 0.55);
   white-space: nowrap;
 }
 
@@ -629,11 +638,11 @@ body {
 }
 .outs-dots-label {
   margin-left: 0.1875rem;
-  letter-spacing: 0.14em;
-  color: rgba(255, 220, 150, 0.62);
-  font-size: 0.625rem;
-  font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
-  font-weight: 700;
+  letter-spacing: 0.18em;
+  color: rgba(255, 220, 150, 0.75);
+  font-size: 0.75rem;
+  font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
+  font-weight: 400;
 }
 .outs-dot {
   display: inline-block;
@@ -696,11 +705,13 @@ body {
   align-items: center;
   gap: 0.625rem;
   padding: 0.25rem 0.625rem 0.25rem 0.875rem;
-  border: 1px solid rgba(120, 100, 60, 0.45);
+  border: 1px solid rgba(251, 191, 36, 0.45);
   border-radius: 0.25rem;
   background: rgba(0, 0, 0, 0.85);
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.6);
-  font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.6),
+    inset 0 0 8px rgba(251, 191, 36, 0.08);
+  font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
 }
 .catchup-card-score-line {
   display: inline-flex;
@@ -708,11 +719,12 @@ body {
   gap: 0.3125rem;
 }
 .catchup-card-score-abbr {
-  font-size: 0.625rem;
-  font-weight: 700;
-  letter-spacing: 0.10em;
+  font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
+  font-size: 0.875rem;
+  font-weight: 400;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
-  color: rgba(255, 220, 150, 0.55);
+  color: rgba(255, 220, 150, 0.7);
   position: relative;
 }
 /* Batting indicator — small triangular "▸" marker before the abbreviation
@@ -738,19 +750,19 @@ body {
   text-shadow: 0 0 6px rgba(251, 191, 36, 0.55);
 }
 .catchup-card-score-num {
-  /* LED-segment-style numeral. Per the Mattel reference: heavy weight,
-     tight tracking, layered glow so the digit reads as "lit phosphor"
-     not "amber text". The dual shadow gives a tight inner bloom plus a
-     softer halo — same trick a real LED gives off through diffusion. */
-  font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
-  font-size: 1.625rem;
-  font-weight: 900;
+  /* LED-segment-style numeral. Pixel font + layered glow so the digit
+     reads as "lit phosphor" rather than "amber text". The dual shadow
+     gives a tight inner bloom plus a softer halo — same trick a real
+     LED gives off through diffusion. */
+  font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
+  font-size: 1.875rem;
+  font-weight: 400;
   color: #ffe79a;
   text-shadow:
-    0 0 1px rgba(255, 255, 255, 0.65),
-    0 0 4px rgba(251, 191, 36, 0.85),
-    0 0 10px rgba(251, 191, 36, 0.45);
-  letter-spacing: -0.01em;
+    0 0 1px rgba(255, 255, 255, 0.75),
+    0 0 5px rgba(251, 191, 36, 0.95),
+    0 0 12px rgba(251, 191, 36, 0.55);
+  letter-spacing: 0;
   line-height: 1;
   min-width: 1.1ch;
   text-align: center;
@@ -1119,13 +1131,11 @@ body {
    read as siblings on the same panel. */
 .field-shell {
   position: relative;
-  /* Aspect-1 LCD window. Width drives, aspect-ratio derives height,
+  /* Aspect-1 CRT window. Width drives, aspect-ratio derives height,
      max-height keeps it from overflowing the flex cell on short
-     viewports. Per BRAINDUMP "field becomes the unquestioned focal
-     point" — the shell no longer caps at 22rem; it grows to whichever
-     constraint hits first (width or available card height). The bezel
-     border is held to one near-invisible hairline so the field reads as
-     "screen suspended in darkness," not "boxed-in panel". */
+     viewports. Brighter bezel border + a darker vignette around the
+     panel sells the "lit screen suspended in darkness" identity from
+     vintage tabletop electronic games. */
   width: 100%;
   max-width: 100%;
   max-height: 100%;
@@ -1133,12 +1143,52 @@ body {
   aspect-ratio: 1 / 1;
   background: #000;
   border-radius: var(--device-radius-screen);
-  border: 1px solid rgba(245, 181, 54, 0.10);
+  border: 1px solid rgba(251, 191, 36, 0.28);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.7),
-    inset 0 0 0 1px rgba(0, 0, 0, 0.85);
+    inset 0 0 0 1px rgba(0, 0, 0, 0.85),
+    inset 0 0 28px rgba(0, 0, 0, 0.85),
+    0 0 0 1px rgba(251, 191, 36, 0.08),
+    0 0 18px rgba(251, 191, 36, 0.08);
   isolation: isolate;
-  overflow: visible;
+  overflow: hidden;
+}
+/* CRT scanline overlay — repeating-linear-gradient is GPU-cheap and
+   sells the "phosphor screen" identity without animated cost. Sits on
+   top of the field SVG via z-index 2; pointer-events disabled so it
+   never intercepts taps. The vertical mask makes the lines visibly
+   "roll" subtly via animation. */
+.field-shell::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  background:
+    /* Horizontal scanlines */
+    repeating-linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0) 0px,
+      rgba(0, 0, 0, 0) 2px,
+      rgba(0, 0, 0, 0.22) 2px,
+      rgba(0, 0, 0, 0.22) 3px
+    ),
+    /* Vignette darkening at the corners — bulges the screen visually */
+    radial-gradient(
+      ellipse 100% 80% at 50% 50%,
+      rgba(0, 0, 0, 0) 60%,
+      rgba(0, 0, 0, 0.45) 100%
+    );
+  mix-blend-mode: multiply;
+  border-radius: inherit;
+  animation: crt-scan-drift 8s linear infinite;
+}
+@keyframes crt-scan-drift {
+  0%   { background-position: 0 0,    0 0; }
+  100% { background-position: 0 3px,  0 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .field-shell::after { animation: none; }
 }
 /* "Stadium glow" — a barely-perceptible amber radial that breathes very
    slowly. Subliminal: the user shouldn't see a shimmer, only sense the
@@ -1189,15 +1239,22 @@ body {
   position: relative;
   z-index: 1;
   display: block;
-  /* Imperceptible global beam-current drift on the whole field. Period
-     7.3s — incommensurable with the 3.4 / 4.2 / 5.1 / 9.7s ambient
-     animations so no beat frequency emerges. */
-  animation: phosphor-breath 7.3s ease-in-out infinite;
+  /* Snappier beam-current drift — period dropped to 2.1s with a wider
+     brightness band so the "live phosphor" feel is actually perceptible
+     instead of subliminal. Plus a constant amber boost via saturate()
+     so every lit stroke reads with vintage-CRT vibrance. */
+  filter: saturate(1.25);
+  animation: phosphor-breath 2.1s steps(6, end) infinite;
 }
 @keyframes phosphor-breath {
-  0%, 100% { filter: brightness(1.000); }
-  25%      { filter: brightness(0.978); }
-  60%      { filter: brightness(1.014); }
+  0%, 100% { filter: saturate(1.25) brightness(1);    }
+  20%      { filter: saturate(1.25) brightness(1.06); }
+  35%      { filter: saturate(1.25) brightness(0.94); }
+  55%      { filter: saturate(1.25) brightness(1.04); }
+  80%      { filter: saturate(1.25) brightness(0.97); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .field-svg { animation: none; filter: saturate(1.25); }
 }
 
 /* ── Mound rubber: ambient bloom + warmup pulse just before the pitch. ── */
@@ -1230,23 +1287,34 @@ body {
    amplitude is held below the "perceptible shimmer" threshold so the
    variation reads as material, not as a filter. */
 .field-wall-segment {
-  animation: phosphor-wall-flicker 3.4s ease-in-out infinite;
+  /* Stepped flicker — discrete frame transitions read as bulb dropouts
+     rather than smooth opacity easing. Period 1.3s lands in the "alive
+     LED" range. */
+  animation: phosphor-wall-flicker 1.3s steps(8, end) infinite;
 }
 @keyframes phosphor-wall-flicker {
-  0%, 100% { stroke-opacity: 0.92; }
-  18%      { stroke-opacity: 0.88; }
-  35%      { stroke-opacity: 0.94; }
-  52%      { stroke-opacity: 0.87; }
-  71%      { stroke-opacity: 0.91; }
-  89%      { stroke-opacity: 0.95; }
+  0%, 100% { stroke-opacity: 1.00; }
+  12%      { stroke-opacity: 0.78; }
+  25%      { stroke-opacity: 1.00; }
+  37%      { stroke-opacity: 0.86; }
+  50%      { stroke-opacity: 1.00; }
+  62%      { stroke-opacity: 0.92; }
+  75%      { stroke-opacity: 1.00; }
+  87%      { stroke-opacity: 0.82; }
 }
 .field-foul-line {
-  animation: phosphor-foul-flicker 5.1s ease-in-out infinite;
+  animation: phosphor-foul-flicker 1.7s steps(6, end) infinite;
 }
 @keyframes phosphor-foul-flicker {
-  0%, 100% { stroke-opacity: 0.75; }
-  40%      { stroke-opacity: 0.71; }
-  70%      { stroke-opacity: 0.77; }
+  0%, 100% { stroke-opacity: 0.95; }
+  20%      { stroke-opacity: 0.78; }
+  40%      { stroke-opacity: 1.00; }
+  60%      { stroke-opacity: 0.85; }
+  80%      { stroke-opacity: 0.98; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .field-wall-segment,
+  .field-foul-line { animation: none; }
 }
 
 /* ── Base bulbs — three lifecycles drive the cross-fade. ── */
@@ -1287,14 +1355,15 @@ body {
 /* Pre/post pair animates the same way as BaseBulb — the "before" name
    dims out and the "after" name fades in during the runners phase. */
 .field-base-label {
-  fill: rgba(255, 220, 150, 0.78);
-  font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
-  letter-spacing: 0.04em;
+  fill: #fff3b0;
+  font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
+  letter-spacing: 0.06em;
   paint-order: stroke;
-  stroke: rgba(0, 0, 0, 0.75);
-  stroke-width: 2.4;
+  stroke: rgba(0, 0, 0, 0.92);
+  stroke-width: 2.8;
   stroke-linejoin: round;
   pointer-events: none;
+  filter: drop-shadow(0 0 2px rgba(255, 207, 64, 0.8));
   transition: opacity 180ms ease-out;
 }
 .field-base-label[data-lifecycle="pre"]  { opacity: 0; }
@@ -1321,14 +1390,15 @@ body {
 
 /* Batter at the plate — visible during setup/pitch/trigger only. */
 .field-batter-label {
-  fill: rgba(255, 220, 150, 0.85);
-  font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
-  letter-spacing: 0.06em;
+  fill: #fff7c4;
+  font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
+  letter-spacing: 0.08em;
   paint-order: stroke;
-  stroke: rgba(0, 0, 0, 0.85);
-  stroke-width: 2.4;
+  stroke: rgba(0, 0, 0, 0.95);
+  stroke-width: 2.8;
   stroke-linejoin: round;
   pointer-events: none;
+  filter: drop-shadow(0 0 3px rgba(255, 207, 64, 0.85));
   opacity: 0;
   transition: opacity 220ms ease-out;
 }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,6 +1,29 @@
 import type { Metadata, Viewport } from "next";
 import Script from "next/script";
+import { VT323, Press_Start_2P } from "next/font/google";
 import "./globals.css";
+
+// Retro CRT mono — used for field labels, scoreboard chips, and any
+// "device readout" surface. VT323 reads like a 70s/80s vector-monitor
+// font without the chunkiness of Press Start 2P, so it's legible at the
+// small sizes the field labels need. next/font self-hosts the file so
+// CSP `font-src 'self'` is satisfied without widening the policy.
+const fontPixelMono = VT323({
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-pixel-mono",
+  display: "swap",
+});
+
+// Chunky arcade pixel — reserved for headline display elements
+// (inning labels, result chip primary). Used sparingly because it stops
+// being readable below ~10px.
+const fontPixelDisplay = Press_Start_2P({
+  weight: "400",
+  subsets: ["latin"],
+  variable: "--font-pixel-display",
+  display: "swap",
+});
 import { TopNav } from "@/components/layout/TopNav";
 import { ThemeProvider } from "@/components/layout/ThemeProvider";
 import { Footer } from "@/components/layout/Footer";
@@ -59,7 +82,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   const siteUrl = getSiteUrl();
   const plausibleDomain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN ?? getSiteHost();
   return (
-    <html lang="en" className="dark" suppressHydrationWarning>
+    <html
+      lang="en"
+      className={`dark ${fontPixelMono.variable} ${fontPixelDisplay.variable}`}
+      suppressHydrationWarning
+    >
       <head>
         <Script
           defer

--- a/web/src/components/catchup/BaseballLightField.tsx
+++ b/web/src/components/catchup/BaseballLightField.tsx
@@ -547,7 +547,7 @@ export function BaseballLightField({
             x2={FOUL_LEFT.x}
             y2={FOUL_LEFT.y}
             className="field-foul-line"
-            stroke="rgba(245, 181, 54, 0.75)"
+            stroke="rgba(255, 207, 64, 0.95)"
             strokeWidth="2"
             strokeLinecap="square"
             style={{ animationDelay: "0ms" }}
@@ -558,7 +558,7 @@ export function BaseballLightField({
             x2={FOUL_RIGHT.x}
             y2={FOUL_RIGHT.y}
             className="field-foul-line"
-            stroke="rgba(245, 181, 54, 0.75)"
+            stroke="rgba(255, 207, 64, 0.95)"
             strokeWidth="2"
             strokeLinecap="square"
             style={{ animationDelay: "1700ms" }}
@@ -569,8 +569,8 @@ export function BaseballLightField({
                 L${POS.second.x},${POS.second.y}
                 L${POS.third.x},${POS.third.y} Z`}
             fill="none"
-            stroke="rgba(245, 181, 54, 0.78)"
-            strokeWidth="2"
+            stroke="rgba(255, 207, 64, 0.98)"
+            strokeWidth="2.5"
             strokeLinejoin="miter"
           />
         </g>
@@ -586,8 +586,8 @@ export function BaseballLightField({
             x2={s.x2}
             y2={s.y2}
             className="field-wall-segment"
-            stroke="rgba(245, 181, 54, 0.92)"
-            strokeWidth="2.5"
+            stroke="rgba(255, 207, 64, 1)"
+            strokeWidth="3"
             strokeLinecap="square"
             style={{
               animationDelay: `${(i * 370 + (i % 3) * 130) % 2800}ms`,
@@ -601,8 +601,8 @@ export function BaseballLightField({
           className="field-mound-dot"
           cx={POS.mound.x}
           cy={POS.mound.y}
-          r="3"
-          fill="rgba(251, 191, 36, 0.95)"
+          r="3.5"
+          fill="rgba(255, 215, 80, 1)"
         />
 
         {/* Home plate — wireframe pentagon, no fill. The flat edge faces
@@ -615,8 +615,8 @@ export function BaseballLightField({
               L${POS.home.x},${POS.home.y + 12}
               L${POS.home.x - 11},${POS.home.y + 3} Z`}
           fill="none"
-          stroke="rgba(251, 191, 36, 0.85)"
-          strokeWidth="1.5"
+          stroke="rgba(255, 215, 80, 1)"
+          strokeWidth="2"
           strokeLinejoin="miter"
         />
 
@@ -642,25 +642,28 @@ export function BaseballLightField({
         <BaseBulb pos={POS.third}  base="third"  prior={baseStatePrior?.third}  before={baseStateBefore.third}  after={after.third}  />
 
         {/* Runner-name labels. Prior/pre/post triple handles the bridge +
-            play cross-fade. */}
+            play cross-fade. When the base IS occupied but the name is
+            missing (upstream gap), a placeholder is rendered so the
+            runner is never invisible — the bulb + label always agree on
+            "someone is here." */}
         <BaseLabel anchor="first"
-          prior={baseStatePrior?.first ? runnerNamesPrior?.first : undefined}
-          before={baseStateBefore.first ? runnerNamesBefore?.first : undefined}
-          after={after.first ? runnerNamesAfter?.first : undefined}
+          prior={runnerLabel(baseStatePrior?.first, runnerNamesPrior?.first)}
+          before={runnerLabel(baseStateBefore.first, runnerNamesBefore?.first)}
+          after={runnerLabel(after.first, runnerNamesAfter?.first)}
         />
         <BaseLabel anchor="second"
-          prior={baseStatePrior?.second ? runnerNamesPrior?.second : undefined}
-          before={baseStateBefore.second ? runnerNamesBefore?.second : undefined}
-          after={after.second ? runnerNamesAfter?.second : undefined}
+          prior={runnerLabel(baseStatePrior?.second, runnerNamesPrior?.second)}
+          before={runnerLabel(baseStateBefore.second, runnerNamesBefore?.second)}
+          after={runnerLabel(after.second, runnerNamesAfter?.second)}
         />
         <BaseLabel anchor="third"
-          prior={baseStatePrior?.third ? runnerNamesPrior?.third : undefined}
-          before={baseStateBefore.third ? runnerNamesBefore?.third : undefined}
-          after={after.third ? runnerNamesAfter?.third : undefined}
+          prior={runnerLabel(baseStatePrior?.third, runnerNamesPrior?.third)}
+          before={runnerLabel(baseStateBefore.third, runnerNamesBefore?.third)}
+          after={runnerLabel(after.third, runnerNamesAfter?.third)}
         />
 
         {batterLabel && (() => {
-          const upper = compactLabel(batterLabel).toUpperCase();
+          const upper = batterLabel.trim().toUpperCase();
           return (
             <text
               className="field-batter-label"
@@ -822,6 +825,27 @@ export function BaseballLightField({
 
 // ── Sub-components ────────────────────────────────────────
 
+/**
+ * Resolve the label that should appear at a base given (state, name).
+ *
+ * Three cases:
+ *   - base empty                        → `undefined` (no label, no bulb)
+ *   - base occupied + name known        → the name itself
+ *   - base occupied + name missing      → "ON BASE" placeholder so the
+ *                                          bulb is never orphaned
+ *
+ * Upstream backend gaps (a `runner_names` map that doesn't list a base
+ * the `base_state` says is occupied) used to render a lit bulb with no
+ * label — visually reads as "ghost runner." The placeholder restores
+ * the runner's existence.
+ */
+function runnerLabel(occupied: boolean | undefined, name: string | undefined): string | undefined {
+  if (!occupied) return undefined;
+  const trimmed = name?.trim();
+  if (trimmed) return trimmed;
+  return "ON BASE";
+}
+
 function BaseLabel({
   anchor,
   prior,
@@ -834,9 +858,9 @@ function BaseLabel({
   after?: string;
 }) {
   if (!prior && !before && !after) return null;
-  const priorLabel = prior ? compactLabel(prior) : null;
-  const beforeLabel = before ? compactLabel(before) : null;
-  const afterLabel = after ? compactLabel(after) : null;
+  const priorLabel = prior ? prior.trim() : null;
+  const beforeLabel = before ? before.trim() : null;
+  const afterLabel = after ? after.trim() : null;
   // No state change at all — just render the persistent label.
   if (
     priorLabel === beforeLabel &&
@@ -908,28 +932,15 @@ function BaseLabelText({
   );
 }
 
-/** Last name only, returned at full length. The SVG <text> font-size
- *  shrinks adaptively for long names instead of truncating to ugly
- *  stems ("SODERSTROM" must NOT become "SODERSTRO"). */
-function compactLabel(full: string): string {
-  const trimmed = full.trim();
-  if (!trimmed) return "";
-  const parts = trimmed.split(/\s+/);
-  let last = parts[parts.length - 1];
-  if (/^(Jr\.?|Sr\.?|II|III|IV)$/i.test(last) && parts.length >= 2) {
-    last = parts[parts.length - 2];
-  }
-  return last.replace(/[.,;]$/, "");
-}
-
-/** Per-label font size — shrinks for long names so we never need to
- *  truncate. Calibrated to keep the longest plausible MLB last names
- *  (e.g. "GUERRERO", "BAZZANA", "WALLNER") readable in the 320 viewBox. */
+/** Per-label font size — shrinks for long full names so we never need to
+ *  truncate. Calibrated for first-and-last MLB names ("AARON JUDGE",
+ *  "VLADIMIR GUERRERO JR.", "ORLANDO ARCIA") in the 320 viewBox. */
 function labelFontSize(text: string): number {
-  if (text.length <= 7) return 9;
-  if (text.length <= 9) return 8;
-  if (text.length <= 11) return 7;
-  return 6.2;
+  if (text.length <= 8) return 8.5;
+  if (text.length <= 12) return 7.5;
+  if (text.length <= 16) return 6.5;
+  if (text.length <= 20) return 5.6;
+  return 5;
 }
 
 function BaseShape({ pos }: { pos: { x: number; y: number } }) {
@@ -944,8 +955,8 @@ function BaseShape({ pos }: { pos: { x: number; y: number } }) {
         width={14}
         height={14}
         fill="none"
-        stroke="rgba(251, 191, 36, 0.6)"
-        strokeWidth={1.25}
+        stroke="rgba(255, 215, 80, 0.95)"
+        strokeWidth={1.75}
         shapeRendering="crispEdges"
       />
     </g>

--- a/web/src/components/catchup/CatchupCard.tsx
+++ b/web/src/components/catchup/CatchupCard.tsx
@@ -249,13 +249,17 @@ export const CatchupCard = forwardRef<HTMLDivElement, CatchupCardProps>(function
             data-team-abbr={card.battingTeamAbbr ?? ""}
           >
             {situation.batterName && (
-              <span className="catchup-card-batter">{compactName(situation.batterName).toUpperCase()}</span>
+              <span className="catchup-card-batter" title={situation.batterName}>
+                {situation.batterName.trim().toUpperCase()}
+              </span>
             )}
             {situation.batterName && situation.pitcherName && (
               <span className="catchup-card-vs" aria-hidden>vs</span>
             )}
             {situation.pitcherName && (
-              <span className="catchup-card-pitcher">{compactName(situation.pitcherName).toUpperCase()}</span>
+              <span className="catchup-card-pitcher" title={situation.pitcherName}>
+                {situation.pitcherName.trim().toUpperCase()}
+              </span>
             )}
             {hasCount && (
               <span className="catchup-card-count">
@@ -438,25 +442,6 @@ function OutsDots({
       <span className="outs-dots-label">{after === 1 ? "OUT" : "OUTS"}</span>
     </span>
   );
-}
-
-/**
- * Squeeze a full player name down for header display. The deck builder
- * sometimes ships "First Last" and sometimes ships just "Last" — the
- * matchup row should render the latter regardless. Strips a trailing
- * Jr./Sr./II/III suffix the way the SDA narrative.py last-name helper
- * does, so "Vladimir Guerrero Jr." → "GUERRERO".
- */
-function compactName(name: string): string {
-  const trimmed = name.trim();
-  if (!trimmed) return trimmed;
-  const parts = trimmed.split(/\s+/);
-  if (parts.length === 1) return parts[0];
-  const last = parts[parts.length - 1];
-  if (/^(jr\.?|sr\.?|ii|iii|iv)$/i.test(last) && parts.length >= 2) {
-    return parts[parts.length - 2].replace(/[.,;]$/, "");
-  }
-  return last.replace(/[.,;]$/, "");
 }
 
 /** True when the priorAfter snapshot disagrees with this card's situation

--- a/web/src/lib/adapters/scroll-down-mlb-deck-adapter.ts
+++ b/web/src/lib/adapters/scroll-down-mlb-deck-adapter.ts
@@ -144,7 +144,15 @@ function adaptPlayCard(
   const movements = card.visual?.runnerMovements ?? [];
   const runnerAdvances = adaptRunnerMovements(movements);
 
-  const ballPath = (card.visual?.trajectory as BallPath | null | undefined) ?? undefined;
+  const rawTrajectory = card.visual?.trajectory as BallPath | null | undefined;
+  // Generic backend `foul` doesn't carry direction. Infer from the
+  // play description ("first base side" / "third base side" / "left" /
+  // "right") so the curl reads correctly. Defaults to left when the
+  // description gives no hint — keeps backward-compatible behavior.
+  const ballPath: BallPath | undefined =
+    rawTrajectory === "foul"
+      ? inferFoulSide(play.description ?? card.description ?? "")
+      : (rawTrajectory ?? undefined);
   const animationProfile = (card.visual?.animationProfile as PlayAnimationProfile | null | undefined) ?? undefined;
   const visualIntensity = (card.visual?.intensity as "low" | "medium" | "high" | null | undefined) ?? undefined;
 
@@ -361,6 +369,32 @@ function pickNarrative(
     return play;
   }
   return card;
+}
+
+
+/**
+ * Choose a foul-side direction from a play description. Looks for
+ * unambiguous "first base side" / "third base side" markers, then for
+ * "right field" / "left field" / "rightfield" / "leftfield", then for
+ * a bare "first base" or "third base" reference. Defaults to "left"
+ * when nothing matches — the historical fallback before the split.
+ */
+function inferFoulSide(description: string): BallPath {
+  const text = description.toLowerCase();
+  // "first base side" / "first-base side" — strongest signal for 1B-side foul.
+  if (/\b(first|1st)[\s-]*base\s+side\b/.test(text)) return "foul_right";
+  if (/\b(third|3rd)[\s-]*base\s+side\b/.test(text)) return "foul_left";
+  // Right-field / left-field foul territory.
+  if (/\bright\s*field\b|\brightfield\b/.test(text)) return "foul_right";
+  if (/\bleft\s*field\b|\bleftfield\b/.test(text)) return "foul_left";
+  // Bare "first/third base" reference — usually a fielder catching the foul.
+  if (/\bfirst\s*base(?:man)?\b|\b1b\b/.test(text)) return "foul_right";
+  if (/\bthird\s*base(?:man)?\b|\b3b\b/.test(text)) return "foul_left";
+  // Bare directional hint ("down the right-field line", "into the
+  // first-base dugout") — last resort before defaulting.
+  if (/\bright\b/.test(text)) return "foul_right";
+  if (/\bleft\b/.test(text)) return "foul_left";
+  return "foul_left";
 }
 
 

--- a/web/src/lib/trajectory.ts
+++ b/web/src/lib/trajectory.ts
@@ -95,8 +95,10 @@ const PATH_SPEC: Partial<Record<BallPath, TrajectorySpec>> = {
   home_run_right:  { class: "home_run", end: FIELDER_POS.rf, arcFactor: 0.30, apexShift: -0.08 },
 
   // Popup + foul use special-case builders below.
-  popup: { class: "popup", end: FIELD_POINTS.home }, // ignored
-  foul:  { class: "foul",  end: FIELD_POINTS.home }, // ignored
+  popup:      { class: "popup", end: FIELD_POINTS.home }, // ignored
+  foul:       { class: "foul",  end: FIELD_POINTS.home }, // ignored — defaults to left
+  foul_left:  { class: "foul",  end: FIELD_POINTS.home }, // ignored
+  foul_right: { class: "foul",  end: FIELD_POINTS.home }, // ignored
 };
 
 /**
@@ -106,7 +108,11 @@ const PATH_SPEC: Partial<Record<BallPath, TrajectorySpec>> = {
 export function buildTrajectory(path: BallPath): string | null {
   if (path === "none" || path === "pitch") return null;
   if (path === "popup") return buildPopupPath();
-  if (path === "foul") return buildFoulPath();
+  // Generic `foul` defaults to the left side (the historical behavior).
+  // `foul_left` and `foul_right` are explicit and used by the adapter when
+  // it can infer direction from the play description.
+  if (path === "foul" || path === "foul_left") return buildFoulPath("left");
+  if (path === "foul_right") return buildFoulPath("right");
 
   const spec = PATH_SPEC[path];
   if (!spec) return null;
@@ -182,13 +188,21 @@ function buildPopupPath(): string {
   return `M${fmt(home.x)} ${fmt(home.y)} Q${fmt(apex.x)} ${fmt(apex.y)} ${fmt(land.x)} ${fmt(land.y)}`;
 }
 
-/** Short curve into foul territory along the left side. Terminates near
- *  the foul line just outside the basepath (the canonical "foul into the
- *  stands" gesture). */
-function buildFoulPath(): string {
+/** Short curve into foul territory on the named side. Terminates outside
+ *  the basepath/foul line on that side (the canonical "foul into the
+ *  stands" gesture). Mirrors across the home-plate x-axis so left and
+ *  right reads as a true reflection. */
+function buildFoulPath(side: "left" | "right"): string {
   const home = FIELD_POINTS.home;
-  const land = { x: home.x - 78, y: home.y - 12 };
-  const cp = { x: home.x - 30, y: home.y + 6 };
+  const dir = side === "left" ? -1 : 1;
+  // Landing point sits past the basepath in foul territory. y is slightly
+  // ABOVE home plate (y - 12) so the curve reads as "into the air on the
+  // foul side of the line" rather than dribbling behind the catcher.
+  const land = { x: home.x + dir * 78, y: home.y - 12 };
+  // Control point pushes the apex OUT past the foul line so the bezier
+  // visibly arcs into the stands instead of cutting through fair territory.
+  // y > home.y keeps the bow on the catcher side of the basepath.
+  const cp = { x: home.x + dir * 30, y: home.y + 6 };
   return `M${fmt(home.x)} ${fmt(home.y)} Q${fmt(cp.x)} ${fmt(cp.y)} ${fmt(land.x)} ${fmt(land.y)}`;
 }
 
@@ -202,13 +216,22 @@ function fmt(n: number): string {
 
 export function trajectoryClass(path: BallPath): TrajectoryClass | null {
   if (path === "popup") return "popup";
-  if (path === "foul") return "foul";
+  if (path === "foul" || path === "foul_left" || path === "foul_right") return "foul";
   const spec = PATH_SPEC[path];
   return spec?.class ?? null;
 }
 
 export function trajectoryEndpoint(path: BallPath): Point | null {
-  if (path === "popup" || path === "foul" || path === "none" || path === "pitch") return null;
+  if (
+    path === "popup" ||
+    path === "foul" ||
+    path === "foul_left" ||
+    path === "foul_right" ||
+    path === "none" ||
+    path === "pitch"
+  ) {
+    return null;
+  }
   const spec = PATH_SPEC[path];
   if (!spec) return null;
   return spec.class === "home_run" ? projectPastWall(spec.end) : spec.end;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -106,7 +106,14 @@ export interface RunnerNames {
 export type BallPath =
   | "none"
   | "pitch"
+  // Generic foul — kept for backward compatibility with backend payloads
+  // that don't yet split direction. Renders as `foul_left` by default.
   | "foul"
+  // Directional fouls — curl into the stands on the named side. Adapter
+  // selects from the play description ("third base" / "first base", etc.)
+  // when the backend supplies only the generic `foul` value.
+  | "foul_left"
+  | "foul_right"
   // Home runs — exit OVER the wall toward the appropriate outfield zone.
   // No vertical-beam path; HR direction comes from the play description.
   | "home_run_left"

--- a/web/tests/unit/lib/scroll-down-mlb-deck-adapter.test.ts
+++ b/web/tests/unit/lib/scroll-down-mlb-deck-adapter.test.ts
@@ -113,6 +113,60 @@ describe("scroll-down-mlb deck adapter — batter inference + narrative splice",
     );
   });
 
+  it("infers foul_right when the play description mentions first base / right field", () => {
+    const { cards } = adaptDeck(
+      buildDeck(
+        {
+          eventType: "field_out",
+          description: "Aaron Judge pops out to first baseman Pete Alonso in foul territory.",
+        },
+        {
+          trajectory: "foul",
+          animationProfile: "foul",
+        },
+      ),
+    );
+    const play = cards.find((c) => c.kind === "play");
+    if (play?.kind !== "play") throw new Error("expected play card");
+    expect(play.ballPath).toBe("foul_right");
+  });
+
+  it("infers foul_left when the play description mentions third base / left field", () => {
+    const { cards } = adaptDeck(
+      buildDeck(
+        {
+          eventType: "field_out",
+          description: "Aaron Judge pops out to third baseman Jose Ramirez in foul territory.",
+        },
+        {
+          trajectory: "foul",
+          animationProfile: "foul",
+        },
+      ),
+    );
+    const play = cards.find((c) => c.kind === "play");
+    if (play?.kind !== "play") throw new Error("expected play card");
+    expect(play.ballPath).toBe("foul_left");
+  });
+
+  it("defaults foul to foul_left when the description gives no directional hint", () => {
+    const { cards } = adaptDeck(
+      buildDeck(
+        {
+          eventType: "field_out",
+          description: "Aaron Judge pops out in foul territory.",
+        },
+        {
+          trajectory: "foul",
+          animationProfile: "foul",
+        },
+      ),
+    );
+    const play = cards.find((c) => c.kind === "play");
+    if (play?.kind !== "play") throw new Error("expected play card");
+    expect(play.ballPath).toBe("foul_left");
+  });
+
   it("recovers batter from runnerNamesAfter when movement.runner is empty (walk to first)", () => {
     const { cards } = adaptDeck(
       buildDeck(

--- a/web/tests/unit/lib/trajectory.test.ts
+++ b/web/tests/unit/lib/trajectory.test.ts
@@ -6,7 +6,7 @@ import type { BallPath } from "@/lib/types";
 const EPS = 0.5; // half a unit of viewBox tolerance for endpoint comparisons
 
 const ALL_PATHS: BallPath[] = [
-  "none", "pitch", "foul",
+  "none", "pitch", "foul", "foul_left", "foul_right",
   "home_run_left", "home_run_center", "home_run_right",
   "ground_3b", "ground_ss", "ground_p", "ground_2b", "ground_1b",
   "line_left", "line_center", "line_right",
@@ -183,10 +183,41 @@ describe("trajectory: classification table is complete", () => {
       ["fly_lf", "fly"], ["fly_lcf", "fly"], ["fly_cf", "fly"],
       ["fly_rcf", "fly"], ["fly_rf", "fly"],
       ["home_run_left", "home_run"], ["home_run_center", "home_run"], ["home_run_right", "home_run"],
-      ["popup", "popup"], ["foul", "foul"],
+      ["popup", "popup"],
+      ["foul", "foul"], ["foul_left", "foul"], ["foul_right", "foul"],
     ];
     for (const [p, cls] of expected) {
       expect(trajectoryClass(p)).toBe(cls);
     }
   });
 });
+
+describe("trajectory: directional fouls", () => {
+  it("foul_left lands LEFT of home plate; foul_right lands RIGHT", () => {
+    const left = buildTrajectory("foul_left")!;
+    const right = buildTrajectory("foul_right")!;
+    const leftEnd = parseFinalPoint(left);
+    const rightEnd = parseFinalPoint(right);
+    // Home plate x = 160 in the canonical viewBox.
+    expect(leftEnd.x).toBeLessThan(160);
+    expect(rightEnd.x).toBeGreaterThan(160);
+  });
+
+  it("foul and foul_left produce identical SVG paths (backward-compat default)", () => {
+    expect(buildTrajectory("foul")).toBe(buildTrajectory("foul_left"));
+  });
+
+  it("foul_right is the mirror image of foul_left across home-plate's x-axis", () => {
+    const left = parseFinalPoint(buildTrajectory("foul_left")!);
+    const right = parseFinalPoint(buildTrajectory("foul_right")!);
+    expect(left.y).toBeCloseTo(right.y, 5);
+    expect(160 - left.x).toBeCloseTo(right.x - 160, 5);
+  });
+});
+
+function parseFinalPoint(d: string): { x: number; y: number } {
+  // Quadratic bezier — final pair after Q is the endpoint.
+  const m = d.match(/Q\s*[-\d.]+\s+[-\d.]+\s+([-\d.]+)\s+([-\d.]+)/);
+  if (!m) throw new Error(`unparseable path: ${d}`);
+  return { x: Number(m[1]), y: Number(m[2]) };
+}


### PR DESCRIPTION
Resolves four visual issues from the catch-up viewer:

1. Show full pitcher/batter names instead of last-name only.
   Removed compactName/compactLabel truncation in both header and field
   labels. Adaptive labelFontSize now scales to "FIRSTNAME LASTNAME"
   ranges; CSS ellipsis covers anything past the matchup row width.

2. Split foul ballPath into foul_left / foul_right so curls render on
   the correct side. Generic "foul" stays in the BallPath enum for
   backward compat with the backend (defaults to left). The adapter
   infers direction from the play description ("first base"/"third
   base"/"left/right field") so existing backend payloads benefit
   immediately. Backend note: when sports-data-admin starts emitting
   foul_left / foul_right directly, the adapter inference becomes a
   pure fallback.

3. Render an "ON BASE" placeholder label when baseState says occupied
   but runner_names is missing — fixes the "ghost runner" case where a
   bulb lit with no name attached.

4. Retro restyle. Wired VT323 + Press Start 2P via next/font/google
   (self-hosted at build, satisfies font-src 'self'). Field labels,
   matchup row, scoreboard, inning chip, and outs-dots label all
   adopt the pixel font. Brighter amber strokes (255,207,64) on wall
   + foul lines + diamond + home plate; stepped phosphor flicker;
   CRT scanline overlay via .field-shell::after with multiply blend
   and slow drift animation. All animations respect
   prefers-reduced-motion.

Tests: directional foul mirror invariants, adapter foul-side
inference, classification table extended to cover both new ballPaths.
133/133 vitest tests pass; tsc + lint clean; next build succeeds with
fonts wired in.

https://claude.ai/code/session_01FyKnFwk3cDTRNEAiNo7N6U