### PR TITLE
fix(scoreboard): phase count + pitcher stat line; push retro LCD chrome

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -497,12 +497,15 @@ body {
 
 /* Scoreboard-style top rail. Pure dark panel, brighter LED accents on
    the inning + score row. */
-/* Scoreboard inset screen — dark LCD area with subtle inner shadow. */
+/* Scoreboard inset screen — dark LCD area with subtle inner shadow and
+   a faint dot-matrix scanline texture (the retro handheld "LCD glass"
+   look — see .catchup-screen-bg shared mixin below). */
 .catchup-card-header {
   /* Reads as a thin instrumentation strip: tighter padding + gap drop the
      header to ~52px so the field below dominates. Outer margin replaces the
      shell padding (now zero) so the header still sits inside the device
      bevel rather than bleeding to the edge. */
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -510,13 +513,47 @@ body {
   padding: 0.25rem 0.5rem 0.3125rem;
   border: 1px solid var(--device-border-soft);
   border-radius: var(--device-radius-screen);
-  background: var(--device-screen);
+  background:
+    /* Horizontal scanlines — tight enough to feel "LCD glass" rather
+       than a CRT filter. 2px rhythm at 1x reads as ~1.5 lines/px on a
+       phone. */
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.018) 0px,
+      rgba(255, 255, 255, 0.018) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    /* Vertical dot-matrix — half-stop weaker than the horizontals so the
+       grid reads as "dot rows" rather than crossed bars. */
+    repeating-linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.012) 0px,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    var(--device-screen);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.6),
     inset 0 0 14px rgba(0, 0, 0, 0.55),
     inset 0 -1px 0 var(--device-border-bevel);
   font-variant-numeric: tabular-nums;
   font-feature-settings: "tnum";
+}
+/* Subtle vignette inside the LCD screen — the corners darken so the
+   readout pools light toward the center, like a real backlit LCD. */
+.catchup-card-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background: radial-gradient(
+    ellipse at center,
+    transparent 55%,
+    rgba(0, 0, 0, 0.35) 100%
+  );
 }
 /* Meta row — top line of the header. Left band carries inning + outs +
    batting team; right band carries the score. Wraps to two rows on narrow
@@ -549,19 +586,41 @@ body {
 }
 
 /* Matchup line — single-line "BATTER vs PITCHER · 3-1". No eyebrows, no
-   logo, no stat lines. Centered, with overflow-safe truncation on names. */
+   logo, no stat lines. Centered, with overflow-safe truncation on names.
+   The top divider is a dashed pixel-stripe — reads as an LCD bezel
+   separator between the situation row and the matchup row rather than
+   the smooth single hairline a UI panel would use. */
 .catchup-card-matchup {
+  position: relative;
   display: flex;
   align-items: baseline;
   justify-content: center;
   flex-wrap: nowrap;
   gap: 0.4375rem;
-  padding: 0.375rem 0.5rem;
-  border-top: 1px solid rgba(120, 100, 60, 0.25);
+  padding: 0.5rem 0.5rem 0.375rem;
   background:
     linear-gradient(180deg, rgba(251, 191, 36, 0.04) 0%, rgba(0, 0, 0, 0) 70%),
     rgba(0, 0, 0, 0.25);
   min-width: 0;
+}
+.catchup-card-matchup::before {
+  /* Pixel-stripe divider: 4px tick / 4px gap, amber-dim, sat under the
+     LCD glass so the row above and the matchup below feel like separate
+     readouts on the same handheld panel. */
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0.25rem;
+  right: 0.25rem;
+  height: 1px;
+  background: repeating-linear-gradient(
+    to right,
+    rgba(246, 196, 83, 0.28) 0,
+    rgba(246, 196, 83, 0.28) 4px,
+    transparent 4px,
+    transparent 8px
+  );
+  pointer-events: none;
 }
 .catchup-card-batter,
 .catchup-card-pitcher {
@@ -598,8 +657,17 @@ body {
   color: rgba(255, 220, 150, 0.55);
   text-transform: uppercase;
 }
+/* Count read-out — gated behind the settle phase. The data we get from
+   the upstream feed is the count at the END of the AB (4-2 for a walk,
+   2-3 for a strikeout), not before the deciding pitch, so showing it
+   pre-resolution would spoil the play AND look inconsistent with the
+   live state on the field. We hold it dim until settle, then bring it
+   up alongside the result chip + post-play score. */
 .catchup-card-count {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3125rem;
   font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
   font-variant-numeric: tabular-nums;
   font-size: 1rem;
@@ -608,11 +676,37 @@ body {
   color: #fde68a;
   text-shadow: 0 0 4px rgba(251, 191, 36, 0.55);
   white-space: nowrap;
+  opacity: 0;
+  transition: opacity 240ms ease-out;
+}
+.catchup-card-count[data-visible="true"] {
+  opacity: 1;
+  transition: opacity 320ms ease-out 80ms;
+}
+.catchup-card-count-sep {
+  color: rgba(255, 220, 150, 0.32);
+  font-size: 0.625rem;
+}
+.catchup-card-count-value {
+  /* Bracketed LED-readout feel — small ticks frame the number like a
+     handheld game's count window. */
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.1875rem;
+  padding: 0.0625rem 0.25rem;
+  border: 1px solid rgba(251, 191, 36, 0.32);
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.55);
+  box-shadow: inset 0 0 4px rgba(251, 191, 36, 0.10);
 }
 
 /* Pitcher stat line — sits below the matchup row inside the same
    scoreboard inset. Dim, monospaced, low-contrast so it reads as
-   "stat ribbon under the matchup" not as a second header line. */
+   "stat ribbon under the matchup" not as a second header line. Gated
+   behind settle for the same reason the count is: the upstream value
+   is the pitcher's line AFTER this play resolves, so revealing it
+   mid-flight inverts the timing (e.g. 2.0 IP shown while only 2 outs
+   are lit on the dots). */
 .catchup-card-pitcher-line {
   margin: 0;
   padding: 0.125rem 0.5rem 0;
@@ -623,18 +717,39 @@ body {
   letter-spacing: 0.10em;
   color: rgba(255, 220, 150, 0.62);
   text-align: center;
+  opacity: 0;
+  transition: opacity 240ms ease-out;
+}
+.catchup-card-pitcher-line[data-visible="true"] {
+  opacity: 1;
+  transition: opacity 360ms ease-out 120ms;
 }
 
-/* ── Outs dots — three LED bulbs in the situation rail ─── */
+/* ── Outs dots — three LED bulbs in the situation rail ───
+   Chunky recessed-bezel window with the same dot-matrix scanlines as
+   the rest of the LCD glass, so the dots read as "lit segments inside
+   the screen" rather than "round pills sitting on top of UI". */
 .outs-dots {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.4375rem;
   padding: 0.1875rem 0.5rem;
-  border: 1px solid rgba(251, 191, 36, 0.32);
-  border-radius: 0.3125rem;
-  background: rgba(0, 0, 0, 0.55);
-  box-shadow: inset 0 0 6px rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.42);
+  border-radius: 2px;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.02) 0px,
+      rgba(255, 255, 255, 0.02) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    rgba(0, 0, 0, 0.65);
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.55),
+    inset 0 1px 2px rgba(0, 0, 0, 0.55),
+    inset 0 0 6px rgba(251, 191, 36, 0.10);
 }
 .outs-dots-label {
   margin-left: 0.1875rem;
@@ -701,16 +816,31 @@ body {
 }
 
 .catchup-card-score {
+  /* Score window — chunky LED-bezel feel. Double border (outer amber
+     trace + inner black inset shadow) gives the "deep recessed display"
+     character of a Mattel handheld score window. Dot-matrix scanlines
+     bleed under the digits so the LCD glass continues across the panel. */
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.625rem;
   padding: 0.25rem 0.625rem 0.25rem 0.875rem;
-  border: 1px solid rgba(251, 191, 36, 0.45);
-  border-radius: 0.25rem;
-  background: rgba(0, 0, 0, 0.85);
+  border: 1px solid rgba(251, 191, 36, 0.55);
+  border-radius: 2px;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.02) 0px,
+      rgba(255, 255, 255, 0.02) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    rgba(0, 0, 0, 0.88);
   box-shadow:
-    inset 0 0 0 1px rgba(0, 0, 0, 0.6),
-    inset 0 0 8px rgba(251, 191, 36, 0.08);
+    inset 0 0 0 1px rgba(0, 0, 0, 0.7),
+    inset 0 1px 2px rgba(0, 0, 0, 0.65),
+    inset 0 0 10px rgba(251, 191, 36, 0.12),
+    0 0 0 1px rgba(0, 0, 0, 0.6);
   font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
 }
 .catchup-card-score-line {
@@ -814,9 +944,12 @@ body {
 }
 
 /* Result LED strip — same inset-screen vocabulary as the scoreboard,
-   but stretched into a thin amber-edged display under the field. */
+   but stretched into a thin amber-edged display under the field. Inherits
+   the same dot-matrix scanlines as the top header so all three readouts
+   (header / chip / narration) read as the same LCD glass. */
 .catchup-result-chip {
   align-self: stretch;
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -828,6 +961,20 @@ body {
   border: 1px solid var(--device-border);
   border-radius: var(--device-radius-screen);
   background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.018) 0px,
+      rgba(255, 255, 255, 0.018) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    repeating-linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.012) 0px,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
     linear-gradient(180deg, var(--device-screen-deep) 0%, var(--device-screen) 100%);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.65),
@@ -981,7 +1128,22 @@ body {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--device-border-soft);
   border-radius: var(--device-radius-screen);
-  background: var(--device-screen);
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.018) 0px,
+      rgba(255, 255, 255, 0.018) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    repeating-linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.012) 0px,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    var(--device-screen);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.5),
     inset 0 0 10px rgba(0, 0, 0, 0.45);

--- a/web/src/components/catchup/CatchupCard.tsx
+++ b/web/src/components/catchup/CatchupCard.tsx
@@ -262,15 +262,29 @@ export const CatchupCard = forwardRef<HTMLDivElement, CatchupCardProps>(function
               </span>
             )}
             {hasCount && (
-              <span className="catchup-card-count">
-                {(situation.batterName || situation.pitcherName) ? "· " : ""}{situation.balls}-{situation.strikes}
+              <span
+                className="catchup-card-count"
+                data-visible={showAfter ? "true" : "false"}
+                aria-hidden={!showAfter}
+              >
+                {(situation.batterName || situation.pitcherName) && (
+                  <span className="catchup-card-count-sep" aria-hidden>·</span>
+                )}
+                <span className="catchup-card-count-value">
+                  {situation.balls}-{situation.strikes}
+                </span>
               </span>
             )}
           </div>
         )}
 
         {situation.pitcherStatLine && (
-          <p className="catchup-card-pitcher-line" data-testid="pitcher-stat-line">
+          <p
+            className="catchup-card-pitcher-line"
+            data-testid="pitcher-stat-line"
+            data-visible={showAfter ? "true" : "false"}
+            aria-hidden={!showAfter}
+          >
             {situation.pitcherStatLine}
           </p>
         )}


### PR DESCRIPTION
The upstream feed reports the AB count and pitcher stat line in their
POST-play form — 4-2 for a walk, 2-3 for a strikeout, 2.0 IP shown while
only 2 outs are lit. That made the scoreboard read as "the play already
happened" the instant a card mounted, while the field below was still
animating the pitch. Gate both readouts behind the settle phase (same as
the post-play score) so they fade in alongside the result chip after the
play resolves.

Push the chrome toward the handheld-baseball-game feel called for in the
BRAINDUMP: dot-matrix scanlines across the header / result chip /
narration so the three readouts share the same LCD glass; a chunkier
recessed bezel on the score window + outs window with double inner
shadow; a dashed pixel-stripe divider between the situation row and the
matchup row; and the count value sat in a small bracketed LED pill so it
clicks in at settle as a distinct readout rather than trailing text.