### PR TITLE
Claude/fix scoreboard timing cn u nz

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -495,17 +495,13 @@ body {
   }
 }
 
-/* Scoreboard-style top rail. Pure dark panel, brighter LED accents on
-   the inning + score row. */
-/* Scoreboard inset screen — dark LCD area with subtle inner shadow and
-   a faint dot-matrix scanline texture (the retro handheld "LCD glass"
-   look — see .catchup-screen-bg shared mixin below). */
+/* Scoreboard-style top rail — a flat stadium-scoreboard panel above
+   the field. Dropped the dot-matrix scanlines + corner vignette that
+   were giving it a CRT/LCD-glass feel; the user called that surface
+   out as "too futuristic" alongside the field. Stays dark so the
+   field's bright green still dominates, just without the screen-glass
+   pretense. */
 .catchup-card-header {
-  /* Reads as a thin instrumentation strip: tighter padding + gap drop the
-     header to ~52px so the field below dominates. Outer margin replaces the
-     shell padding (now zero) so the header still sits inside the device
-     bevel rather than bleeding to the edge. */
-  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -513,47 +509,13 @@ body {
   padding: 0.25rem 0.5rem 0.3125rem;
   border: 1px solid var(--device-border-soft);
   border-radius: var(--device-radius-screen);
-  background:
-    /* Horizontal scanlines — tight enough to feel "LCD glass" rather
-       than a CRT filter. 2px rhythm at 1x reads as ~1.5 lines/px on a
-       phone. */
-    repeating-linear-gradient(
-      to bottom,
-      rgba(255, 255, 255, 0.018) 0px,
-      rgba(255, 255, 255, 0.018) 1px,
-      transparent 1px,
-      transparent 2px
-    ),
-    /* Vertical dot-matrix — half-stop weaker than the horizontals so the
-       grid reads as "dot rows" rather than crossed bars. */
-    repeating-linear-gradient(
-      to right,
-      rgba(255, 255, 255, 0.012) 0px,
-      rgba(255, 255, 255, 0.012) 1px,
-      transparent 1px,
-      transparent 2px
-    ),
-    var(--device-screen);
+  background: var(--device-screen);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.6),
     inset 0 0 14px rgba(0, 0, 0, 0.55),
     inset 0 -1px 0 var(--device-border-bevel);
   font-variant-numeric: tabular-nums;
   font-feature-settings: "tnum";
-}
-/* Subtle vignette inside the LCD screen — the corners darken so the
-   readout pools light toward the center, like a real backlit LCD. */
-.catchup-card-header::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  border-radius: inherit;
-  background: radial-gradient(
-    ellipse at center,
-    transparent 55%,
-    rgba(0, 0, 0, 0.35) 100%
-  );
 }
 /* Meta row — top line of the header. Left band carries inning + outs +
    batting team; right band carries the score. Wraps to two rows on narrow
@@ -725,31 +687,21 @@ body {
   transition: opacity 360ms ease-out 120ms;
 }
 
-/* ── Outs dots — three LED bulbs in the situation rail ───
-   Chunky recessed-bezel window with the same dot-matrix scanlines as
-   the rest of the LCD glass, so the dots read as "lit segments inside
-   the screen" rather than "round pills sitting on top of UI". */
+/* ── Outs dots — three indicator pills in the situation rail ──
+   Simple recessed panel — the LCD scanline overlay has been removed.
+   Stays dark with a hint of amber inner glow so the lit dots have a
+   surface to sit on. */
 .outs-dots {
-  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.4375rem;
   padding: 0.1875rem 0.5rem;
-  border: 1px solid rgba(251, 191, 36, 0.42);
+  border: 1px solid rgba(251, 191, 36, 0.32);
   border-radius: 2px;
-  background:
-    repeating-linear-gradient(
-      to bottom,
-      rgba(255, 255, 255, 0.02) 0px,
-      rgba(255, 255, 255, 0.02) 1px,
-      transparent 1px,
-      transparent 2px
-    ),
-    rgba(0, 0, 0, 0.65);
+  background: rgba(0, 0, 0, 0.55);
   box-shadow:
-    inset 0 0 0 1px rgba(0, 0, 0, 0.55),
-    inset 0 1px 2px rgba(0, 0, 0, 0.55),
-    inset 0 0 6px rgba(251, 191, 36, 0.10);
+    inset 0 1px 1px rgba(0, 0, 0, 0.45),
+    inset 0 0 6px rgba(251, 191, 36, 0.08);
 }
 .outs-dots-label {
   margin-left: 0.1875rem;
@@ -816,31 +768,22 @@ body {
 }
 
 .catchup-card-score {
-  /* Score window — chunky LED-bezel feel. Double border (outer amber
-     trace + inner black inset shadow) gives the "deep recessed display"
-     character of a Mattel handheld score window. Dot-matrix scanlines
-     bleed under the digits so the LCD glass continues across the panel. */
-  position: relative;
+  /* Score window — a flat dark scoreboard panel above the field. Kept
+     the chunky recessed inner shadow that makes the digits feel like
+     they sit "inside" the panel, but dropped the LCD scanline overlay
+     so it doesn't read as a screen. Thin amber trace at the border
+     just to mark the panel edge. */
   display: inline-flex;
   align-items: center;
   gap: 0.625rem;
   padding: 0.25rem 0.625rem 0.25rem 0.875rem;
-  border: 1px solid rgba(251, 191, 36, 0.55);
+  border: 1px solid rgba(251, 191, 36, 0.45);
   border-radius: 2px;
-  background:
-    repeating-linear-gradient(
-      to bottom,
-      rgba(255, 255, 255, 0.02) 0px,
-      rgba(255, 255, 255, 0.02) 1px,
-      transparent 1px,
-      transparent 2px
-    ),
-    rgba(0, 0, 0, 0.88);
+  background: rgba(0, 0, 0, 0.88);
   box-shadow:
     inset 0 0 0 1px rgba(0, 0, 0, 0.7),
     inset 0 1px 2px rgba(0, 0, 0, 0.65),
-    inset 0 0 10px rgba(251, 191, 36, 0.12),
-    0 0 0 1px rgba(0, 0, 0, 0.6);
+    inset 0 0 8px rgba(251, 191, 36, 0.08);
   font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
 }
 .catchup-card-score-line {
@@ -943,13 +886,11 @@ body {
   }
 }
 
-/* Result LED strip — same inset-screen vocabulary as the scoreboard,
-   but stretched into a thin amber-edged display under the field. Inherits
-   the same dot-matrix scanlines as the top header so all three readouts
-   (header / chip / narration) read as the same LCD glass. */
+/* Result chip — the thin stadium-scoreboard strip that latches the
+   play outcome at settle. Same flat-panel vocabulary as the header
+   above; the dot-matrix LCD overlay has been retired. */
 .catchup-result-chip {
   align-self: stretch;
-  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -960,22 +901,7 @@ body {
   min-height: 2.25rem;
   border: 1px solid var(--device-border);
   border-radius: var(--device-radius-screen);
-  background:
-    repeating-linear-gradient(
-      to bottom,
-      rgba(255, 255, 255, 0.018) 0px,
-      rgba(255, 255, 255, 0.018) 1px,
-      transparent 1px,
-      transparent 2px
-    ),
-    repeating-linear-gradient(
-      to right,
-      rgba(255, 255, 255, 0.012) 0px,
-      rgba(255, 255, 255, 0.012) 1px,
-      transparent 1px,
-      transparent 2px
-    ),
-    linear-gradient(180deg, var(--device-screen-deep) 0%, var(--device-screen) 100%);
+  background: linear-gradient(180deg, var(--device-screen-deep) 0%, var(--device-screen) 100%);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.65),
     inset 0 0 12px rgba(0, 0, 0, 0.5),
@@ -1128,22 +1054,7 @@ body {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--device-border-soft);
   border-radius: var(--device-radius-screen);
-  background:
-    repeating-linear-gradient(
-      to bottom,
-      rgba(255, 255, 255, 0.018) 0px,
-      rgba(255, 255, 255, 0.018) 1px,
-      transparent 1px,
-      transparent 2px
-    ),
-    repeating-linear-gradient(
-      to right,
-      rgba(255, 255, 255, 0.012) 0px,
-      rgba(255, 255, 255, 0.012) 1px,
-      transparent 1px,
-      transparent 2px
-    ),
-    var(--device-screen);
+  background: var(--device-screen);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.5),
     inset 0 0 10px rgba(0, 0, 0, 0.45);
@@ -1288,195 +1199,87 @@ body {
 
 /* Outer shell — dark "tabletop console" panel. The amber glow is reserved
    for actual lit elements; the surround stays cool/dark for contrast. */
-/* Field inset screen — sits inside the device shell as the largest
-   "display" area. Same screen treatment as the scoreboard so the two
-   read as siblings on the same panel. */
+/* Field inset screen — the largest "display" area on the card.
+   Switched from the LCD/CRT-glass treatment to a flat dark stadium
+   surround so the kelly-green field reads as a painted-on Mattel-
+   handheld baseball diamond rather than a backlit screen. The CRT
+   scanlines, amber bezel, stadium glow, and phosphor breathing have
+   all been retired here — they were the "too futuristic" surface the
+   user called out. */
 .field-shell {
   position: relative;
-  /* Aspect-1 CRT window. Width drives, aspect-ratio derives height,
-     max-height keeps it from overflowing the flex cell on short
-     viewports. Brighter bezel border + a darker vignette around the
-     panel sells the "lit screen suspended in darkness" identity from
-     vintage tabletop electronic games. */
   width: 100%;
   max-width: 100%;
   max-height: 100%;
   margin: auto;
   aspect-ratio: 1 / 1;
-  background: #000;
+  /* Dark warning-track / dead-zone surround. Sits behind the
+     fair-territory green so the corners of the SVG viewBox don't
+     paint as bright green — only the pentagon does. */
+  background: #050807;
   border-radius: var(--device-radius-screen);
-  border: 1px solid rgba(251, 191, 36, 0.28);
+  border: 1px solid rgba(245, 239, 220, 0.10);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.7),
     inset 0 0 0 1px rgba(0, 0, 0, 0.85),
-    inset 0 0 28px rgba(0, 0, 0, 0.85),
-    0 0 0 1px rgba(251, 191, 36, 0.08),
-    0 0 18px rgba(251, 191, 36, 0.08);
+    inset 0 0 28px rgba(0, 0, 0, 0.7);
   isolation: isolate;
   overflow: hidden;
 }
-/* CRT scanline overlay — repeating-linear-gradient is GPU-cheap and
-   sells the "phosphor screen" identity without animated cost. Sits on
-   top of the field SVG via z-index 2; pointer-events disabled so it
-   never intercepts taps. The vertical mask makes the lines visibly
-   "roll" subtly via animation. */
-.field-shell::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: 2;
-  pointer-events: none;
-  background:
-    /* Horizontal scanlines */
-    repeating-linear-gradient(
-      to bottom,
-      rgba(0, 0, 0, 0) 0px,
-      rgba(0, 0, 0, 0) 2px,
-      rgba(0, 0, 0, 0.22) 2px,
-      rgba(0, 0, 0, 0.22) 3px
-    ),
-    /* Vignette darkening at the corners — bulges the screen visually */
-    radial-gradient(
-      ellipse 100% 80% at 50% 50%,
-      rgba(0, 0, 0, 0) 60%,
-      rgba(0, 0, 0, 0.45) 100%
-    );
-  mix-blend-mode: multiply;
-  border-radius: inherit;
-  animation: crt-scan-drift 8s linear infinite;
-}
-@keyframes crt-scan-drift {
-  0%   { background-position: 0 0,    0 0; }
-  100% { background-position: 0 3px,  0 0; }
-}
-@media (prefers-reduced-motion: reduce) {
-  .field-shell::after { animation: none; }
-}
-/* "Stadium glow" — a barely-perceptible amber radial that breathes very
-   slowly. Subliminal: the user shouldn't see a shimmer, only sense the
-   panel is "alive." Absolute rgba contribution stays in 0.0225-0.03. */
+/* The .field-stadium-glow element is still rendered but the CRT-amber
+   pulse it used to host has been retired. Kept as an empty hook so
+   the JSX doesn't have to branch on env, and so future ambient
+   treatments (a flicker of stadium lights, etc.) can rejoin here
+   without restructuring the layer stack. */
 .field-stadium-glow {
   position: absolute;
   inset: 0;
   pointer-events: none;
   z-index: 0;
-  background: radial-gradient(
-    ellipse 70% 55% at 50% 45%,
-    rgba(245, 181, 54, 0.05) 0%,
-    transparent 100%
-  );
-  animation: stadium-ambient-pulse 9.7s ease-in-out infinite;
-  will-change: opacity;
-}
-@keyframes stadium-ambient-pulse {
-  0%, 100% { opacity: 0.60; }
-  45%      { opacity: 0.45; }
-}
-/* During an active contact play, the ambient breath is replaced by a
-   reactive radial gradient that brightens with the ball in flight —
-   the field "feels" the impact. Walks/strikeouts/etc. (data-contact=
-   "false") keep the ambient pulse; nothing fires when there's no ball. */
-[data-playing="true"][data-contact="true"] .field-stadium-glow {
-  animation: ball-flight-glow var(--d-ball, 400ms) ease-out
-             var(--ms-ball, 800ms) both;
-}
-@keyframes ball-flight-glow {
-  0%   { background: radial-gradient(ellipse 70% 55% at 50% 45%, rgba(245, 181, 54, 0.00) 0%, transparent 100%); }
-  30%  { background: radial-gradient(ellipse 70% 55% at 50% 45%, rgba(245, 181, 54, 0.14) 0%, transparent 100%); }
-  100% { background: radial-gradient(ellipse 70% 55% at 50% 45%, rgba(245, 181, 54, 0.04) 0%, transparent 100%); }
-}
-/* Home-run flare — peaks at ~15% then decays over 2s so the stadium
-   reads as bathed in the afterglow of a long ball. Higher specificity
-   than ball-flight-glow above, so it wins on home_run plays. */
-[data-homer="true"][data-playing="true"] .field-stadium-glow {
-  animation: homer-flare 2s ease-out var(--ms-ball, 800ms) both;
-}
-@keyframes homer-flare {
-  0%   { background: radial-gradient(ellipse 80% 65% at 50% 45%, rgba(245, 181, 54, 0.00) 0%, transparent 100%); }
-  15%  { background: radial-gradient(ellipse 80% 65% at 50% 45%, rgba(255, 217, 122, 0.38) 0%, transparent 100%); }
-  60%  { background: radial-gradient(ellipse 80% 65% at 50% 45%, rgba(245, 181, 54, 0.18) 0%, transparent 100%); }
-  100% { background: radial-gradient(ellipse 80% 65% at 50% 45%, rgba(245, 181, 54, 0.04) 0%, transparent 100%); }
 }
 .field-svg {
   position: relative;
   z-index: 1;
   display: block;
-  /* Snappier beam-current drift — period dropped to 2.1s with a wider
-     brightness band so the "live phosphor" feel is actually perceptible
-     instead of subliminal. Plus a constant amber boost via saturate()
-     so every lit stroke reads with vintage-CRT vibrance. */
-  filter: saturate(1.25);
-  animation: phosphor-breath 2.1s steps(6, end) infinite;
-}
-@keyframes phosphor-breath {
-  0%, 100% { filter: saturate(1.25) brightness(1);    }
-  20%      { filter: saturate(1.25) brightness(1.06); }
-  35%      { filter: saturate(1.25) brightness(0.94); }
-  55%      { filter: saturate(1.25) brightness(1.04); }
-  80%      { filter: saturate(1.25) brightness(0.97); }
-}
-@media (prefers-reduced-motion: reduce) {
-  .field-svg { animation: none; filter: saturate(1.25); }
 }
 
-/* ── Mound rubber: ambient bloom + warmup pulse just before the pitch. ── */
-.field-mound-dot {
-  filter: drop-shadow(0 0 3px rgba(251, 191, 36, 0.85));
-  transform-box: fill-box;
-  transform-origin: center;
-  animation: mound-ambient-bloom 4.2s ease-in-out infinite;
+/* ── Grass + dirt fills ──────────────────────────────────
+   Two solid colors, no gradients — the user asked for "one green
+   color, one dirt color." Picked to feel like the Mattel handheld
+   reference: bright kelly green with deep black dirt. The dirt is
+   intentionally black (not brown) because that's what the reference
+   does, and the contrast against green is sharper than any tan would
+   give. */
+.field-grass {
+  fill: #2d8b3c;
 }
-[data-playing="true"] .field-mound-dot {
-  /* Warmup sits just before the pitch fires; replaces the ambient bloom. */
-  animation: field-mound-warmup 0.5s ease-out
-    calc(var(--ms-pitch, 500ms) - 200ms) 1 forwards;
-}
-@keyframes mound-ambient-bloom {
-  0%, 100% { filter: drop-shadow(0 0 3px   rgba(251, 191, 36, 0.85)); }
-  30%      { filter: drop-shadow(0 0 4.5px rgba(251, 191, 36, 1.00)); }
-  65%      { filter: drop-shadow(0 0 2.5px rgba(251, 191, 36, 0.72)); }
-}
-@keyframes field-mound-warmup {
-  0%   { transform: scale(1);   opacity: 0.85; }
-  60%  { transform: scale(1.5); opacity: 1; }
-  100% { transform: scale(1);   opacity: 0.85; }
+.field-dirt {
+  fill: #0a0d0b;
 }
 
-/* ── Wall segments / foul lines: per-element phosphor jitter. ──────────
-   Each wall segment carries an animation-delay derived from its index
-   (set inline in BaseballLightField.tsx). Periods are incommensurable
-   with the other ambient cycles (9.7 / 7.3 / 5.1 / 4.2 / 3.4s) and
-   amplitude is held below the "perceptible shimmer" threshold so the
-   variation reads as material, not as a filter. */
-.field-wall-segment {
-  /* Stepped flicker — discrete frame transitions read as bulb dropouts
-     rather than smooth opacity easing. Period 1.3s lands in the "alive
-     LED" range. */
-  animation: phosphor-wall-flicker 1.3s steps(8, end) infinite;
-}
-@keyframes phosphor-wall-flicker {
-  0%, 100% { stroke-opacity: 1.00; }
-  12%      { stroke-opacity: 0.78; }
-  25%      { stroke-opacity: 1.00; }
-  37%      { stroke-opacity: 0.86; }
-  50%      { stroke-opacity: 1.00; }
-  62%      { stroke-opacity: 0.92; }
-  75%      { stroke-opacity: 1.00; }
-  87%      { stroke-opacity: 0.82; }
+/* ── Wall arc / foul lines ───────────────────────────────
+   Cream-white strokes, no amber phosphor flicker. The wall is a
+   single thin arc now (no segmented chunks), reads as the painted
+   warning-track edge from the Mattel reference. */
+.field-wall {
+  stroke-opacity: 0.85;
 }
 .field-foul-line {
-  animation: phosphor-foul-flicker 1.7s steps(6, end) infinite;
-}
-@keyframes phosphor-foul-flicker {
-  0%, 100% { stroke-opacity: 0.95; }
-  20%      { stroke-opacity: 0.78; }
-  40%      { stroke-opacity: 1.00; }
-  60%      { stroke-opacity: 0.85; }
-  80%      { stroke-opacity: 0.98; }
+  stroke-opacity: 0.95;
 }
 @media (prefers-reduced-motion: reduce) {
-  .field-wall-segment,
   .field-foul-line { animation: none; }
+}
+
+/* Pitcher's rubber — small painted-on pixel on the dirt mound. The
+   old amber LED + ambient bloom + pre-pitch warmup were the loudest
+   "futuristic" element on the field; the rubber is purely structural
+   now, no animation. */
+.field-mound-rubber {
+  shape-rendering: crispEdges;
+}
+.field-home-plate {
+  shape-rendering: geometricPrecision;
 }
 
 /* ── Base bulbs — three lifecycles drive the cross-fade. ── */
@@ -1484,7 +1287,8 @@ body {
    becomes active, "pre" bulbs hold lit through setup, fade out as runners
    advance; "post" bulbs fade in as runners arrive. */
 .field-base-bulb {
-  filter: drop-shadow(0 0 4px rgba(251, 191, 36, 0.85));
+  /* Small team-accent dot inside the white base — reads as "a runner
+     is on this bag" without the amber LED phosphor halo. */
   transform-box: fill-box;
   transform-origin: center;
   transition: opacity 180ms ease-out;
@@ -1515,9 +1319,11 @@ body {
 
 /* ── Base + batter labels: small last-name tags near each base ─────── */
 /* Pre/post pair animates the same way as BaseBulb — the "before" name
-   dims out and the "after" name fades in during the runners phase. */
+   dims out and the "after" name fades in during the runners phase.
+   Cream fill + black halo so the names stay readable whether they sit
+   on the kelly-green grass or the black dirt path beneath them. */
 .field-base-label {
-  fill: #fff3b0;
+  fill: #f5efdc;
   font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
   letter-spacing: 0.06em;
   paint-order: stroke;
@@ -1525,7 +1331,6 @@ body {
   stroke-width: 2.8;
   stroke-linejoin: round;
   pointer-events: none;
-  filter: drop-shadow(0 0 2px rgba(255, 207, 64, 0.8));
   transition: opacity 180ms ease-out;
 }
 .field-base-label[data-lifecycle="pre"]  { opacity: 0; }
@@ -1550,9 +1355,11 @@ body {
   100% { opacity: 1; }
 }
 
-/* Batter at the plate — visible during setup/pitch/trigger only. */
+/* Batter at the plate — visible during setup/pitch/trigger only.
+   Cream fill + heavy black halo so the name reads cleanly when it sits
+   on the dirt alley below home plate. */
 .field-batter-label {
-  fill: #fff7c4;
+  fill: #f5efdc;
   font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
   letter-spacing: 0.08em;
   paint-order: stroke;
@@ -1560,7 +1367,6 @@ body {
   stroke-width: 2.8;
   stroke-linejoin: round;
   pointer-events: none;
-  filter: drop-shadow(0 0 3px rgba(255, 207, 64, 0.85));
   opacity: 0;
   transition: opacity 220ms ease-out;
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -249,7 +249,7 @@ body {
   font-weight: 700;
   letter-spacing: 0.20em;
   text-transform: uppercase;
-  color: var(--device-amber-dim, rgb(155, 118, 38));
+  color: rgba(245, 239, 220, 0.55);
 }
 
 /* ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -259,26 +259,33 @@ body {
    vocabulary (gradient shell + bevel + amber border); non-featured
    cards stay flat with quieter amber borders so scanning isn't muddy.
    ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ */
+/* The home page now shares the catch-up viewer's stadium palette so the
+   transition from the games list into a game doesn't feel like crossing
+   between two different products. The amber-on-black tokens that used
+   to live here were the same "neon on black" surface the user called
+   out across the field overhaul — replaced with a grass / dirt / cream
+   set so the menu reads as the same Mattel-handheld baseball machine
+   as the catch-up screen. */
 .home-deck-page {
-  background-color: #080a0d;
+  background-color: #050807;
   min-height: 100dvh;
 }
 .home-deck {
-  --home-card-bg:                    #13141a;
-  --home-card-bg-featured:           #15161a;
-  --home-grad-featured:              linear-gradient(180deg, #1d1f24 0%, #15161a 100%);
-  --home-card-border:                rgba(245, 181, 54, 0.14);
-  --home-card-border-featured:       rgba(245, 181, 54, 0.32);
-  --home-card-border-hover:          rgba(245, 181, 54, 0.28);
-  --home-card-border-featured-hover: rgba(245, 181, 54, 0.50);
-  --home-cta-color:                  #f6c453;
-  --home-cta-bg:                     rgba(246, 196, 83, 0.12);
-  --home-cta-border:                 rgba(246, 196, 83, 0.38);
-  --home-badge-border:               rgba(245, 181, 54, 0.22);
-  --home-badge-border-soft:          rgba(245, 181, 54, 0.16);
-  --home-badge-text:                 #9b7626;
-  --home-sep-color:                  rgba(245, 181, 54, 0.30);
-  --home-team-text:                  #f5f1e8;
+  --home-card-bg:                    #0b110d;
+  --home-card-bg-featured:           #0d1610;
+  --home-grad-featured:              linear-gradient(180deg, #122019 0%, #0b110d 100%);
+  --home-card-border:                rgba(245, 239, 220, 0.10);
+  --home-card-border-featured:       rgba(245, 239, 220, 0.22);
+  --home-card-border-hover:          rgba(245, 239, 220, 0.22);
+  --home-card-border-featured-hover: rgba(245, 239, 220, 0.38);
+  --home-cta-color:                  #f5efdc;
+  --home-cta-bg:                     rgba(45, 139, 60, 0.18);
+  --home-cta-border:                 rgba(45, 139, 60, 0.55);
+  --home-badge-border:               rgba(245, 239, 220, 0.16);
+  --home-badge-border-soft:          rgba(245, 239, 220, 0.12);
+  --home-badge-text:                 rgba(245, 239, 220, 0.55);
+  --home-sep-color:                  rgba(245, 239, 220, 0.22);
+  --home-team-text:                  #f5efdc;
 }
 
 /* ── Catch-up page shell ─────────────────────────────
@@ -350,20 +357,26 @@ body {
      The whole catch-up experience is one retro-handheld product. These
      tokens cascade to every play card, intro card, reveal gate, and
      final-reveal card so the theme stays coherent. */
-  --catchup-bg:          #07080a;
-  --device-shell:        #15161a;
-  --device-shell-hi:     #1d1f24;
-  --device-shell-lo:     #0a0b0d;
-  --device-screen:       #0a0b0d;
-  --device-screen-deep:  #06070a;
-  --device-border:       rgba(245, 181, 54, 0.32);
-  --device-border-soft:  rgba(245, 181, 54, 0.16);
+  --catchup-bg:          #050807;
+  --device-shell:        #0d1610;
+  --device-shell-hi:     #122019;
+  --device-shell-lo:     #07100a;
+  --device-screen:       #060a07;
+  --device-screen-deep:  #030604;
+  /* "Amber" tokens kept under the original name so dozens of selectors
+     across this file (.catchup-card-inning, .outs-dot, ResultChip
+     digits, ScoreSegment, etc.) didn't need a global rename — but the
+     palette is now stadium-cream, not neon amber. The user repeatedly
+     called the amber-on-black surface "neon on black"; cream-on-dark
+     reads as painted-on signage instead. */
+  --device-border:       rgba(245, 239, 220, 0.22);
+  --device-border-soft:  rgba(245, 239, 220, 0.12);
   --device-border-bevel: rgba(255, 255, 255, 0.04);
-  --device-amber:        #f6c453;
-  --device-amber-bright: #ffd97a;
-  --device-amber-dim:    #9b7626;
-  --device-text:         #f5f1e8;
-  --device-muted:        #9ca3af;
+  --device-amber:        #f5efdc;
+  --device-amber-bright: #ffffff;
+  --device-amber-dim:    rgba(245, 239, 220, 0.55);
+  --device-text:         #f5efdc;
+  --device-muted:        rgba(245, 239, 220, 0.55);
   /* Tightened radii — the device feels less "mobile card with rounded
      corners" and more "injection-molded electronic device front panel".
      The inset screens are nearly square (3px) for an LCD-window feel. */
@@ -424,10 +437,10 @@ body {
      gradient + heavy border were making the card read as "an iOS card
      with rounded corners" rather than a screen suspended in darkness. */
   background: transparent;
-  border: 1px solid rgba(245, 181, 54, calc(var(--lev-border-opacity) * 0.4));
+  border: 1px solid rgba(245, 239, 220, calc(var(--lev-border-opacity) * 0.4));
   border-radius: var(--device-radius);
   box-shadow:
-    0 0 var(--lev-glow-radius) rgba(246, 196, 83, var(--lev-glow-alpha));
+    0 0 var(--lev-glow-radius) rgba(245, 239, 220, var(--lev-glow-alpha));
   transition: border-color 600ms ease, box-shadow 600ms ease;
 }
 
@@ -478,13 +491,13 @@ body {
 }
 @keyframes leverage-settle-pulse {
   0% {
-    box-shadow: 0 0 var(--lev-glow-radius) rgba(246, 196, 83, var(--lev-glow-alpha));
+    box-shadow: 0 0 var(--lev-glow-radius) rgba(245, 239, 220, var(--lev-glow-alpha));
   }
   60% {
-    box-shadow: 0 0 calc(var(--lev-glow-radius) * 1.8) rgba(246, 196, 83, calc(var(--lev-glow-alpha) + 0.22));
+    box-shadow: 0 0 calc(var(--lev-glow-radius) * 1.8) rgba(245, 239, 220, calc(var(--lev-glow-alpha) + 0.22));
   }
   100% {
-    box-shadow: 0 0 var(--lev-glow-radius) rgba(246, 196, 83, var(--lev-glow-alpha));
+    box-shadow: 0 0 var(--lev-glow-radius) rgba(245, 239, 220, var(--lev-glow-alpha));
   }
 }
 @media (max-width: 480px) {
@@ -542,8 +555,8 @@ body {
   font-size: 0.9375rem;
   font-weight: 400;
   letter-spacing: 0.14em;
-  color: var(--lev-amber, #fde68a);
-  text-shadow: 0 0 var(--lev-glow-radius, 8px) rgba(251, 191, 36, 0.6);
+  color: var(--lev-amber, #f5efdc);
+  text-shadow: 0 0 var(--lev-glow-radius, 8px) rgba(245, 239, 220, 0.6);
   transition: color 600ms ease, text-shadow 600ms ease;
 }
 
@@ -561,7 +574,7 @@ body {
   gap: 0.4375rem;
   padding: 0.5rem 0.5rem 0.375rem;
   background:
-    linear-gradient(180deg, rgba(251, 191, 36, 0.04) 0%, rgba(0, 0, 0, 0) 70%),
+    linear-gradient(180deg, rgba(245, 239, 220, 0.04) 0%, rgba(0, 0, 0, 0) 70%),
     rgba(0, 0, 0, 0.25);
   min-width: 0;
 }
@@ -577,8 +590,8 @@ body {
   height: 1px;
   background: repeating-linear-gradient(
     to right,
-    rgba(246, 196, 83, 0.28) 0,
-    rgba(246, 196, 83, 0.28) 4px,
+    rgba(245, 239, 220, 0.28) 0,
+    rgba(245, 239, 220, 0.28) 4px,
     transparent 4px,
     transparent 8px
   );
@@ -601,14 +614,14 @@ body {
   flex: 0 1 auto;
 }
 .catchup-card-batter {
-  color: #fff7c4;
+  color: #f5efdc;
   text-shadow:
-    0 0 4px rgba(255, 207, 64, 0.85),
-    0 0 10px rgba(251, 191, 36, 0.55);
+    0 0 4px rgba(245, 239, 220, 0.85),
+    0 0 10px rgba(245, 239, 220, 0.55);
 }
 .catchup-card-pitcher {
   color: rgba(255, 220, 140, 0.95);
-  text-shadow: 0 0 6px rgba(251, 191, 36, 0.45);
+  text-shadow: 0 0 6px rgba(245, 239, 220, 0.45);
 }
 .catchup-card-vs {
   flex: 0 0 auto;
@@ -635,8 +648,8 @@ body {
   font-size: 1rem;
   font-weight: 400;
   letter-spacing: 0.12em;
-  color: #fde68a;
-  text-shadow: 0 0 4px rgba(251, 191, 36, 0.55);
+  color: #f5efdc;
+  text-shadow: 0 0 4px rgba(245, 239, 220, 0.55);
   white-space: nowrap;
   opacity: 0;
   transition: opacity 240ms ease-out;
@@ -656,10 +669,10 @@ body {
   align-items: baseline;
   gap: 0.1875rem;
   padding: 0.0625rem 0.25rem;
-  border: 1px solid rgba(251, 191, 36, 0.32);
+  border: 1px solid rgba(245, 239, 220, 0.32);
   border-radius: 2px;
   background: rgba(0, 0, 0, 0.55);
-  box-shadow: inset 0 0 4px rgba(251, 191, 36, 0.10);
+  box-shadow: inset 0 0 4px rgba(245, 239, 220, 0.10);
 }
 
 /* Pitcher stat line — sits below the matchup row inside the same
@@ -696,12 +709,12 @@ body {
   align-items: center;
   gap: 0.4375rem;
   padding: 0.1875rem 0.5rem;
-  border: 1px solid rgba(251, 191, 36, 0.32);
+  border: 1px solid rgba(245, 239, 220, 0.32);
   border-radius: 2px;
   background: rgba(0, 0, 0, 0.55);
   box-shadow:
     inset 0 1px 1px rgba(0, 0, 0, 0.45),
-    inset 0 0 6px rgba(251, 191, 36, 0.08);
+    inset 0 0 6px rgba(245, 239, 220, 0.08);
 }
 .outs-dots-label {
   margin-left: 0.1875rem;
@@ -716,55 +729,55 @@ body {
   width: 9px;
   height: 9px;
   border-radius: 50%;
-  border: 1px solid rgba(251, 191, 36, 0.45);
+  border: 1px solid rgba(245, 239, 220, 0.45);
   background: transparent;
   box-shadow: none;
   transition: background 240ms ease-out, box-shadow 240ms ease-out, transform 240ms ease-out;
   transform-origin: center;
 }
 .outs-dot[data-state="on"] {
-  background: #fbbf24;
+  background: #f5efdc;
   border-color: transparent;
   box-shadow:
-    0 0 4px rgba(251, 191, 36, 1),
-    0 0 9px rgba(251, 191, 36, 0.6),
-    0 0 16px rgba(251, 191, 36, 0.25);
+    0 0 4px rgba(245, 239, 220, 1),
+    0 0 9px rgba(245, 239, 220, 0.6),
+    0 0 16px rgba(245, 239, 220, 0.25);
 }
 .outs-dot[data-state="off"] {
   background: transparent;
 }
 /* Settled (non-playing) state: lighting dot is already lit; fading dot is dim. */
 .outs-dot[data-state="lighting"] {
-  background: #fbbf24;
+  background: #f5efdc;
   border-color: transparent;
-  box-shadow: 0 0 4px rgba(251, 191, 36, 0.85), 0 0 9px rgba(251, 191, 36, 0.45);
+  box-shadow: 0 0 4px rgba(245, 239, 220, 0.85), 0 0 9px rgba(245, 239, 220, 0.45);
 }
 .outs-dot[data-state="fading"] {
   background: transparent;
-  border-color: rgba(251, 191, 36, 0.35);
+  border-color: rgba(245, 239, 220, 0.35);
 }
 /* While the card is playing: lighting dots animate ON at the runners phase;
    fading dots (rare — would mean an out went down somehow) animate OFF. */
 [data-active="true"] .outs-dot[data-state="lighting"] {
   background: transparent;
-  border-color: rgba(251, 191, 36, 0.55);
+  border-color: rgba(245, 239, 220, 0.55);
   box-shadow: none;
   animation: outs-light-up 0.4s ease-out var(--ms-runners, 1.5s) forwards;
 }
 [data-active="true"] .outs-dot[data-state="fading"] {
-  background: #fbbf24;
+  background: #f5efdc;
   border-color: transparent;
-  box-shadow: 0 0 4px rgba(251, 191, 36, 0.85);
+  box-shadow: 0 0 4px rgba(245, 239, 220, 0.85);
   animation: outs-fade-out 0.35s ease-out var(--ms-runners, 1.5s) forwards;
 }
 @keyframes outs-light-up {
-  0%   { background: transparent; box-shadow: none; transform: scale(1); border-color: rgba(251, 191, 36, 0.55); }
-  60%  { background: #fbbf24; box-shadow: 0 0 12px rgba(251, 191, 36, 0.95); transform: scale(1.5); border-color: transparent; }
-  100% { background: #fbbf24; box-shadow: 0 0 4px rgba(251, 191, 36, 0.85), 0 0 9px rgba(251, 191, 36, 0.45); transform: scale(1); border-color: transparent; }
+  0%   { background: transparent; box-shadow: none; transform: scale(1); border-color: rgba(245, 239, 220, 0.55); }
+  60%  { background: #f5efdc; box-shadow: 0 0 12px rgba(245, 239, 220, 0.95); transform: scale(1.5); border-color: transparent; }
+  100% { background: #f5efdc; box-shadow: 0 0 4px rgba(245, 239, 220, 0.85), 0 0 9px rgba(245, 239, 220, 0.45); transform: scale(1); border-color: transparent; }
 }
 @keyframes outs-fade-out {
-  0%   { background: #fbbf24; box-shadow: 0 0 4px rgba(251, 191, 36, 0.85); }
-  100% { background: transparent; box-shadow: none; border-color: rgba(251, 191, 36, 0.35); }
+  0%   { background: #f5efdc; box-shadow: 0 0 4px rgba(245, 239, 220, 0.85); }
+  100% { background: transparent; box-shadow: none; border-color: rgba(245, 239, 220, 0.35); }
 }
 
 .catchup-card-score {
@@ -777,13 +790,13 @@ body {
   align-items: center;
   gap: 0.625rem;
   padding: 0.25rem 0.625rem 0.25rem 0.875rem;
-  border: 1px solid rgba(251, 191, 36, 0.45);
+  border: 1px solid rgba(245, 239, 220, 0.45);
   border-radius: 2px;
   background: rgba(0, 0, 0, 0.88);
   box-shadow:
     inset 0 0 0 1px rgba(0, 0, 0, 0.7),
     inset 0 1px 2px rgba(0, 0, 0, 0.65),
-    inset 0 0 8px rgba(251, 191, 36, 0.08);
+    inset 0 0 8px rgba(245, 239, 220, 0.08);
   font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
 }
 .catchup-card-score-line {
@@ -805,8 +818,8 @@ body {
    line; the eye picks it up faster than a label, and it's always next to
    the team name in the score panel. */
 .catchup-card-score-line[data-batting="true"] .catchup-card-score-abbr {
-  color: #fde68a;
-  text-shadow: 0 0 4px rgba(251, 191, 36, 0.55);
+  color: #f5efdc;
+  text-shadow: 0 0 4px rgba(245, 239, 220, 0.55);
 }
 .catchup-card-score-line[data-batting="true"] .catchup-card-score-abbr::before {
   content: "▸";
@@ -815,12 +828,12 @@ body {
   top: 50%;
   transform: translateY(-50%);
   font-size: 0.625rem;
-  color: #fbbf24;
-  text-shadow: 0 0 5px rgba(251, 191, 36, 0.85);
+  color: #f5efdc;
+  text-shadow: 0 0 5px rgba(245, 239, 220, 0.85);
 }
 .catchup-card-score-line[data-batting="true"] .catchup-card-score-num {
   color: #ffffff;
-  text-shadow: 0 0 6px rgba(251, 191, 36, 0.55);
+  text-shadow: 0 0 6px rgba(245, 239, 220, 0.55);
 }
 .catchup-card-score-num {
   /* LED-segment-style numeral. Pixel font + layered glow so the digit
@@ -830,11 +843,11 @@ body {
   font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
   font-size: 1.875rem;
   font-weight: 400;
-  color: #ffe79a;
+  color: #fff8e0;
   text-shadow:
     0 0 1px rgba(255, 255, 255, 0.75),
-    0 0 5px rgba(251, 191, 36, 0.95),
-    0 0 12px rgba(251, 191, 36, 0.55);
+    0 0 5px rgba(245, 239, 220, 0.95),
+    0 0 12px rgba(245, 239, 220, 0.55);
   letter-spacing: 0;
   line-height: 1;
   min-width: 1.1ch;
@@ -850,12 +863,12 @@ body {
   animation: catchup-score-flash 520ms cubic-bezier(0.4, 0, 0.5, 1) forwards;
 }
 @keyframes catchup-score-flash {
-  0%   { transform: scale(1);    color: #fde68a; }
+  0%   { transform: scale(1);    color: #f5efdc; }
   25%  { transform: scale(1.18); color: #ffffff;
          text-shadow:
            0 0 4px rgba(255, 255, 255, 0.95),
-           0 0 12px rgba(251, 191, 36, 0.85); }
-  100% { transform: scale(1);    color: #fde68a; }
+           0 0 12px rgba(245, 239, 220, 0.85); }
+  100% { transform: scale(1);    color: #f5efdc; }
 }
 .catchup-card-score-sep {
   color: rgba(255, 220, 150, 0.32);
@@ -927,7 +940,7 @@ body {
   font-weight: 800;
   letter-spacing: 0.16em;
   color: var(--device-amber-bright);
-  text-shadow: 0 0 6px rgba(245, 181, 54, 0.45);
+  text-shadow: 0 0 6px rgba(245, 239, 220, 0.45);
   line-height: 1;
 }
 .catchup-result-chip-secondary {
@@ -964,7 +977,7 @@ body {
 }
 .catchup-result-chip[data-tier="1"] .catchup-result-chip-primary {
   font-size: 1.125rem;
-  text-shadow: 0 0 6px rgba(246, 196, 83, 0.35);
+  text-shadow: 0 0 6px rgba(245, 239, 220, 0.35);
 }
 @keyframes chip-tier1-pop {
   0%   { opacity: 0; transform: scale(0.90); }
@@ -978,7 +991,7 @@ body {
 }
 .catchup-result-chip[data-tier="2"] .catchup-result-chip-primary {
   font-size: 1.25rem;
-  text-shadow: 0 0 12px rgba(246, 196, 83, 0.65);
+  text-shadow: 0 0 12px rgba(245, 239, 220, 0.65);
 }
 .catchup-result-chip[data-tier="2"] .catchup-result-chip-secondary {
   color: var(--device-amber);
@@ -1001,13 +1014,13 @@ body {
   letter-spacing: 0.08em;
   text-shadow:
     0 0 20px rgba(255, 217, 122, 0.9),
-    0 0 40px rgba(246, 196, 83, 0.45),
+    0 0 40px rgba(245, 239, 220, 0.45),
     0 0 2px rgba(255, 255, 255, 0.6);
 }
 .catchup-result-chip[data-tier="3"] .catchup-result-chip-secondary {
   font-size: 0.9375rem;
   color: var(--device-amber-bright);
-  text-shadow: 0 0 8px rgba(246, 196, 83, 0.5);
+  text-shadow: 0 0 8px rgba(245, 239, 220, 0.5);
 }
 @keyframes chip-tier3-epic {
   0%   { opacity: 0; transform: scale(0.80); }
@@ -1103,7 +1116,7 @@ body {
   display: flex;
   justify-content: center;
   margin: 0.25rem auto 0.5rem;
-  color: rgba(251, 191, 36, 0.40);
+  color: rgba(245, 239, 220, 0.40);
   opacity: 0;
   transition: opacity 320ms ease-out;
 }
@@ -1389,7 +1402,7 @@ body {
 .field-pitch-pulse {
   /* Single subtle drop-shadow — the previous double-glow streaked under
      motion blur and read as a vertical beam on some displays. */
-  filter: drop-shadow(0 0 3px rgba(251, 191, 36, 0.75));
+  filter: drop-shadow(0 0 3px rgba(245, 239, 220, 0.75));
 }
 [data-playing="true"] .field-pitch-pulse {
   animation: field-pitch var(--d-pitch, 380ms) cubic-bezier(0.45, 0, 0.55, 1)
@@ -1428,9 +1441,9 @@ body {
 @keyframes field-strikeout {
   /* Compact pulse at the plate — used to scale to 2× and read as a
      dramatic burst, but the spec calls for "small pulse, no big beam." */
-  0%   { fill: rgba(251, 191, 36, 0);    transform: scale(0.8); }
-  35%  { fill: rgba(251, 191, 36, 0.85); transform: scale(1.2); }
-  100% { fill: rgba(251, 191, 36, 0);    transform: scale(1.4); }
+  0%   { fill: rgba(245, 239, 220, 0);    transform: scale(0.8); }
+  35%  { fill: rgba(245, 239, 220, 0.85); transform: scale(1.2); }
+  100% { fill: rgba(245, 239, 220, 0);    transform: scale(1.4); }
 }
 
 /* ── HBP flash — red-tinted pulse at the plate (no contact bloom). ── */
@@ -1693,7 +1706,7 @@ body {
   /* See .catchup-card-snap rationale — chassis goes near-transparent so
      the inset screens carry the visual weight, not the bezel. */
   background: transparent;
-  border: 1px solid rgba(245, 181, 54, 0.18);
+  border: 1px solid rgba(245, 239, 220, 0.18);
   border-radius: var(--device-radius);
 }
 
@@ -1724,7 +1737,7 @@ body {
   font-weight: 800;
   letter-spacing: 0.32em;
   color: var(--device-amber);
-  text-shadow: 0 0 6px rgba(245, 181, 54, 0.45);
+  text-shadow: 0 0 6px rgba(245, 239, 220, 0.45);
 }
 .scene-setter-firstpitch {
   margin: 0;
@@ -1840,7 +1853,7 @@ body {
   font-weight: 800;
   letter-spacing: 0.20em;
   color: var(--device-amber-bright);
-  text-shadow: 0 0 6px rgba(245, 181, 54, 0.45);
+  text-shadow: 0 0 6px rgba(245, 239, 220, 0.45);
 }
 .scene-setter-cta-sub {
   margin: 0;
@@ -1872,7 +1885,7 @@ body {
 .reveal-gate-stadium {
   position: absolute;
   inset: 0;
-  background: radial-gradient(ellipse at center, rgba(245, 181, 54, 0.10), transparent 60%);
+  background: radial-gradient(ellipse at center, rgba(245, 239, 220, 0.10), transparent 60%);
   opacity: 0;
   transition: opacity 600ms ease-out;
   pointer-events: none;
@@ -1891,7 +1904,7 @@ body {
   max-width: 24rem;
   padding: 1.25rem 1rem;
   background: transparent;
-  border: 1px solid rgba(245, 181, 54, 0.18);
+  border: 1px solid rgba(245, 239, 220, 0.18);
   border-radius: var(--device-radius);
 }
 .reveal-gate-headline {
@@ -1914,14 +1927,14 @@ body {
   border: 1px solid var(--device-border);
   border-radius: var(--device-radius-screen);
   background:
-    linear-gradient(180deg, rgba(245, 181, 54, 0.18) 0%, rgba(245, 181, 54, 0.10) 100%);
+    linear-gradient(180deg, rgba(245, 239, 220, 0.18) 0%, rgba(245, 239, 220, 0.10) 100%);
   color: var(--device-amber-bright);
   font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
   font-size: 0.875rem;
   font-weight: 800;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  text-shadow: 0 0 6px rgba(245, 181, 54, 0.45);
+  text-shadow: 0 0 6px rgba(245, 239, 220, 0.45);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.04),
     inset 0 -1px 0 rgba(0, 0, 0, 0.4),
@@ -1931,7 +1944,7 @@ body {
 }
 .reveal-gate-button:hover:not(:disabled) {
   background:
-    linear-gradient(180deg, rgba(245, 181, 54, 0.26) 0%, rgba(245, 181, 54, 0.16) 100%);
+    linear-gradient(180deg, rgba(245, 239, 220, 0.26) 0%, rgba(245, 239, 220, 0.16) 100%);
 }
 .reveal-gate-button:disabled { opacity: 0.5; cursor: progress; }
 
@@ -1957,7 +1970,7 @@ body {
   width: calc(100% - 1.5rem);
   max-width: 28rem;
   background: transparent;
-  border: 1px solid rgba(245, 181, 54, 0.18);
+  border: 1px solid rgba(245, 239, 220, 0.18);
   border-radius: var(--device-radius);
 }
 .final-reveal-score {
@@ -2006,11 +2019,11 @@ body {
   line-height: 1.2;
 }
 .final-reveal-team-winner .final-reveal-team-score {
-  color: #ffe79a;
+  color: #fff8e0;
   text-shadow:
     0 0 1px rgba(255, 255, 255, 0.65),
-    0 0 6px rgba(251, 191, 36, 0.85),
-    0 0 14px rgba(251, 191, 36, 0.45);
+    0 0 6px rgba(245, 239, 220, 0.85),
+    0 0 14px rgba(245, 239, 220, 0.45);
 }
 .final-reveal-team-winner .final-reveal-team-name {
   color: var(--device-text);
@@ -2077,21 +2090,21 @@ body {
   border: 1px solid var(--device-border);
   border-radius: var(--device-radius-screen);
   background:
-    linear-gradient(180deg, rgba(245, 181, 54, 0.18) 0%, rgba(245, 181, 54, 0.10) 100%);
+    linear-gradient(180deg, rgba(245, 239, 220, 0.18) 0%, rgba(245, 239, 220, 0.10) 100%);
   color: var(--device-amber-bright);
   font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
   font-size: 0.8125rem;
   font-weight: 800;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  text-shadow: 0 0 6px rgba(245, 181, 54, 0.45);
+  text-shadow: 0 0 6px rgba(245, 239, 220, 0.45);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.04),
     inset 0 -1px 0 rgba(0, 0, 0, 0.4);
 }
 .final-reveal-primary:hover {
   background:
-    linear-gradient(180deg, rgba(245, 181, 54, 0.26) 0%, rgba(245, 181, 54, 0.16) 100%);
+    linear-gradient(180deg, rgba(245, 239, 220, 0.26) 0%, rgba(245, 239, 220, 0.16) 100%);
 }
 .final-reveal-error {
   display: flex;
@@ -2132,7 +2145,7 @@ body {
   padding: 1.25rem 1rem;
   text-align: center;
   background: transparent;
-  border: 1px solid rgba(245, 181, 54, 0.18);
+  border: 1px solid rgba(245, 239, 220, 0.18);
   border-radius: var(--device-radius);
 }
 .live-caught-up-fineprint {
@@ -2194,14 +2207,14 @@ body {
   border: 1px solid var(--device-border);
   border-radius: var(--device-radius-screen);
   background:
-    linear-gradient(180deg, rgba(245, 181, 54, 0.18) 0%, rgba(245, 181, 54, 0.10) 100%);
+    linear-gradient(180deg, rgba(245, 239, 220, 0.18) 0%, rgba(245, 239, 220, 0.10) 100%);
   color: var(--device-amber-bright);
   font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
   font-size: 0.8125rem;
   font-weight: 800;
   letter-spacing: 0.16em;
   text-transform: uppercase;
-  text-shadow: 0 0 6px rgba(245, 181, 54, 0.45);
+  text-shadow: 0 0 6px rgba(245, 239, 220, 0.45);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.04),
     inset 0 -1px 0 rgba(0, 0, 0, 0.4);
@@ -2209,7 +2222,7 @@ body {
 }
 .live-caught-up-button:hover:not(:disabled) {
   background:
-    linear-gradient(180deg, rgba(245, 181, 54, 0.26) 0%, rgba(245, 181, 54, 0.16) 100%);
+    linear-gradient(180deg, rgba(245, 239, 220, 0.26) 0%, rgba(245, 239, 220, 0.16) 100%);
 }
 .live-caught-up-button:disabled { opacity: 0.5; }
 
@@ -2274,20 +2287,20 @@ body {
 /* Outs — bridge-lighting dots fire at the bridge→setup boundary so the
    user sees the dot light up before the pitch arrives. */
 .outs-dot[data-state="bridge-lighting"] {
-  background: #fbbf24;
+  background: #f5efdc;
   border-color: transparent;
-  box-shadow: 0 0 4px rgba(251, 191, 36, 0.85), 0 0 9px rgba(251, 191, 36, 0.45);
+  box-shadow: 0 0 4px rgba(245, 239, 220, 0.85), 0 0 9px rgba(245, 239, 220, 0.45);
 }
 [data-active="true"] .outs-dot[data-state="bridge-lighting"] {
   background: transparent;
-  border-color: rgba(251, 191, 36, 0.55);
+  border-color: rgba(245, 239, 220, 0.55);
   box-shadow: none;
   animation: outs-light-up 0.36s ease-out var(--ms-setup, 0.4s) forwards;
 }
 .outs-dot[data-state="bridge-fading-then-on"] {
-  background: #fbbf24;
+  background: #f5efdc;
   border-color: transparent;
-  box-shadow: 0 0 4px rgba(251, 191, 36, 0.85);
+  box-shadow: 0 0 4px rgba(245, 239, 220, 0.85);
 }
 
 /* Field — prior bulbs fade out at bridge end; "pre" bulbs that emerged
@@ -2377,7 +2390,7 @@ body {
   font-weight: 800;
   letter-spacing: 0.18em;
   color: var(--device-amber-bright);
-  text-shadow: 0 0 10px rgba(245, 181, 54, 0.42);
+  text-shadow: 0 0 10px rgba(245, 239, 220, 0.42);
 }
 .rhythm-card-score {
   display: inline-flex;
@@ -2405,11 +2418,11 @@ body {
   font-family: ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
   font-size: 1.625rem;
   font-weight: 900;
-  color: #ffe79a;
+  color: #fff8e0;
   text-shadow:
     0 0 1px rgba(255, 255, 255, 0.65),
-    0 0 4px rgba(251, 191, 36, 0.85),
-    0 0 10px rgba(251, 191, 36, 0.45);
+    0 0 4px rgba(245, 239, 220, 0.85),
+    0 0 10px rgba(245, 239, 220, 0.45);
   line-height: 1;
 }
 .rhythm-card-score-sep {
@@ -2431,12 +2444,12 @@ body {
 .rhythm-card-quiet-stretch .rhythm-card-eyebrow { color: rgba(255, 220, 150, 0.32); }
 .rhythm-card-quiet-stretch .rhythm-card-label {
   color: var(--device-amber);
-  text-shadow: 0 0 6px rgba(245, 181, 54, 0.28);
+  text-shadow: 0 0 6px rgba(245, 239, 220, 0.28);
 }
 
 /* Late game — slightly brighter, the device "wakes up". */
 .rhythm-card-late-game .rhythm-card-label {
-  text-shadow: 0 0 14px rgba(245, 181, 54, 0.65);
+  text-shadow: 0 0 14px rgba(245, 239, 220, 0.65);
 }
 .rhythm-card-late-game .rhythm-card-eyebrow {
   color: rgba(255, 220, 150, 0.7);
@@ -2447,7 +2460,7 @@ body {
   color: #fff5cc;
   text-shadow:
     0 0 6px rgba(255, 245, 204, 0.85),
-    0 0 18px rgba(245, 181, 54, 0.55);
+    0 0 18px rgba(245, 239, 220, 0.55);
 }
 .rhythm-card-final-setup .rhythm-card-eyebrow {
   color: rgba(255, 220, 150, 0.85);
@@ -2468,10 +2481,10 @@ body {
 .catchup-lab {
   --lab-bg:        #08090b;
   --lab-panel:     #11141a;
-  --lab-border:    rgba(245, 181, 54, 0.2);
+  --lab-border:    rgba(245, 239, 220, 0.2);
   --lab-text:      #e8e8e8;
   --lab-muted:     #8b95a6;
-  --lab-amber:     #f6c453;
+  --lab-amber:     #f5efdc;
   --lab-amber-dim: #c89a3e;
   background: var(--lab-bg);
   color: var(--lab-text);
@@ -2553,11 +2566,11 @@ body {
   transition: background 120ms ease;
 }
 .lab-fixture-button:hover {
-  background: rgba(245, 181, 54, 0.06);
+  background: rgba(245, 239, 220, 0.06);
 }
 .lab-fixture-button[data-active="true"] {
-  background: rgba(245, 181, 54, 0.14);
-  border-color: rgba(245, 181, 54, 0.35);
+  background: rgba(245, 239, 220, 0.14);
+  border-color: rgba(245, 239, 220, 0.35);
 }
 .lab-fixture-id {
   font-weight: 700;
@@ -2629,7 +2642,7 @@ body {
 }
 .lab-toggle {
   margin-left: 0.5rem;
-  background: rgba(245, 181, 54, 0.1);
+  background: rgba(245, 239, 220, 0.1);
   border: 1px solid var(--lab-border);
   color: var(--lab-amber);
   font-size: 0.625rem;
@@ -2639,7 +2652,7 @@ body {
   border-radius: 4px;
   cursor: pointer;
 }
-.lab-toggle:hover { background: rgba(245, 181, 54, 0.18); }
+.lab-toggle:hover { background: rgba(245, 239, 220, 0.18); }
 .lab-review-notes {
   margin: 0.5rem 0 0;
   padding-left: 1rem;
@@ -2716,7 +2729,7 @@ body {
   font-size: 0.6875rem;
 }
 .lab-toolbar-button {
-  background: rgba(245, 181, 54, 0.1);
+  background: rgba(245, 239, 220, 0.1);
   border: 1px solid var(--lab-border);
   color: var(--lab-amber);
   padding: 0.3125rem 0.625rem;
@@ -2727,10 +2740,10 @@ body {
   cursor: pointer;
   font-family: inherit;
 }
-.lab-toolbar-button:hover { background: rgba(245, 181, 54, 0.2); }
+.lab-toolbar-button:hover { background: rgba(245, 239, 220, 0.2); }
 .lab-toolbar-button--primary {
   font-weight: 700;
-  background: rgba(245, 181, 54, 0.18);
+  background: rgba(245, 239, 220, 0.18);
 }
 .lab-toolbar-group {
   display: flex;
@@ -2758,7 +2771,7 @@ body {
 }
 .lab-toolbar-pill:hover { color: var(--lab-text); }
 .lab-toolbar-pill[data-active="true"] {
-  background: rgba(245, 181, 54, 0.2);
+  background: rgba(245, 239, 220, 0.2);
   border-color: var(--lab-amber);
   color: var(--lab-amber);
 }
@@ -2783,7 +2796,7 @@ body {
   color: var(--lab-muted);
 }
 .lab-toolbar-toggle[data-on="true"] {
-  border-color: rgba(245, 181, 54, 0.5);
+  border-color: rgba(245, 239, 220, 0.5);
 }
 .lab-toolbar-toggle[data-on="true"] .lab-toolbar-toggle-state {
   color: var(--lab-amber);
@@ -2812,11 +2825,11 @@ body {
 }
 .lab-leverage-pip[data-tier="0"] {
   height: 6px;
-  background: rgba(245, 181, 54, 0.25);
+  background: rgba(245, 239, 220, 0.25);
 }
 .lab-leverage-pip[data-tier="1"] {
   height: 12px;
-  background: rgba(245, 181, 54, 0.6);
+  background: rgba(245, 239, 220, 0.6);
 }
 .lab-leverage-pip[data-tier="2"] {
   height: 18px;
@@ -2846,7 +2859,7 @@ body {
 .lab-audit-table td {
   padding: 0.25rem 0.375rem;
   text-align: left;
-  border-bottom: 1px solid rgba(245, 181, 54, 0.08);
+  border-bottom: 1px solid rgba(245, 239, 220, 0.08);
   vertical-align: top;
 }
 .lab-audit-table thead th {
@@ -2949,8 +2962,8 @@ body {
   flex-direction: column;
   gap: 0.125rem;
   padding: 0.375rem 0.5rem;
-  border-left: 2px solid rgba(245, 181, 54, 0.3);
-  background: rgba(245, 181, 54, 0.04);
+  border-left: 2px solid rgba(245, 239, 220, 0.3);
+  background: rgba(245, 239, 220, 0.04);
   border-radius: 0 4px 4px 0;
   counter-increment: lab-rhythm;
 }
@@ -2966,7 +2979,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.1em;
 }
-.lab-rhythm-inning-transition { color: #fbbf24; }
+.lab-rhythm-inning-transition { color: #f5efdc; }
 .lab-rhythm-quiet-stretch     { color: #9ca3af; }
 .lab-rhythm-late-game         { color: #fb923c; }
 .lab-rhythm-final-setup       { color: #fff5cc; }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -497,12 +497,15 @@ body {
 
 /* Scoreboard-style top rail. Pure dark panel, brighter LED accents on
    the inning + score row. */
-/* Scoreboard inset screen — dark LCD area with subtle inner shadow. */
+/* Scoreboard inset screen — dark LCD area with subtle inner shadow and
+   a faint dot-matrix scanline texture (the retro handheld "LCD glass"
+   look — see .catchup-screen-bg shared mixin below). */
 .catchup-card-header {
   /* Reads as a thin instrumentation strip: tighter padding + gap drop the
      header to ~52px so the field below dominates. Outer margin replaces the
      shell padding (now zero) so the header still sits inside the device
      bevel rather than bleeding to the edge. */
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
@@ -510,13 +513,47 @@ body {
   padding: 0.25rem 0.5rem 0.3125rem;
   border: 1px solid var(--device-border-soft);
   border-radius: var(--device-radius-screen);
-  background: var(--device-screen);
+  background:
+    /* Horizontal scanlines — tight enough to feel "LCD glass" rather
+       than a CRT filter. 2px rhythm at 1x reads as ~1.5 lines/px on a
+       phone. */
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.018) 0px,
+      rgba(255, 255, 255, 0.018) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    /* Vertical dot-matrix — half-stop weaker than the horizontals so the
+       grid reads as "dot rows" rather than crossed bars. */
+    repeating-linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.012) 0px,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    var(--device-screen);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.6),
     inset 0 0 14px rgba(0, 0, 0, 0.55),
     inset 0 -1px 0 var(--device-border-bevel);
   font-variant-numeric: tabular-nums;
   font-feature-settings: "tnum";
+}
+/* Subtle vignette inside the LCD screen — the corners darken so the
+   readout pools light toward the center, like a real backlit LCD. */
+.catchup-card-header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background: radial-gradient(
+    ellipse at center,
+    transparent 55%,
+    rgba(0, 0, 0, 0.35) 100%
+  );
 }
 /* Meta row — top line of the header. Left band carries inning + outs +
    batting team; right band carries the score. Wraps to two rows on narrow
@@ -549,19 +586,41 @@ body {
 }
 
 /* Matchup line — single-line "BATTER vs PITCHER · 3-1". No eyebrows, no
-   logo, no stat lines. Centered, with overflow-safe truncation on names. */
+   logo, no stat lines. Centered, with overflow-safe truncation on names.
+   The top divider is a dashed pixel-stripe — reads as an LCD bezel
+   separator between the situation row and the matchup row rather than
+   the smooth single hairline a UI panel would use. */
 .catchup-card-matchup {
+  position: relative;
   display: flex;
   align-items: baseline;
   justify-content: center;
   flex-wrap: nowrap;
   gap: 0.4375rem;
-  padding: 0.375rem 0.5rem;
-  border-top: 1px solid rgba(120, 100, 60, 0.25);
+  padding: 0.5rem 0.5rem 0.375rem;
   background:
     linear-gradient(180deg, rgba(251, 191, 36, 0.04) 0%, rgba(0, 0, 0, 0) 70%),
     rgba(0, 0, 0, 0.25);
   min-width: 0;
+}
+.catchup-card-matchup::before {
+  /* Pixel-stripe divider: 4px tick / 4px gap, amber-dim, sat under the
+     LCD glass so the row above and the matchup below feel like separate
+     readouts on the same handheld panel. */
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0.25rem;
+  right: 0.25rem;
+  height: 1px;
+  background: repeating-linear-gradient(
+    to right,
+    rgba(246, 196, 83, 0.28) 0,
+    rgba(246, 196, 83, 0.28) 4px,
+    transparent 4px,
+    transparent 8px
+  );
+  pointer-events: none;
 }
 .catchup-card-batter,
 .catchup-card-pitcher {
@@ -598,8 +657,17 @@ body {
   color: rgba(255, 220, 150, 0.55);
   text-transform: uppercase;
 }
+/* Count read-out — gated behind the settle phase. The data we get from
+   the upstream feed is the count at the END of the AB (4-2 for a walk,
+   2-3 for a strikeout), not before the deciding pitch, so showing it
+   pre-resolution would spoil the play AND look inconsistent with the
+   live state on the field. We hold it dim until settle, then bring it
+   up alongside the result chip + post-play score. */
 .catchup-card-count {
   flex: 0 0 auto;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3125rem;
   font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
   font-variant-numeric: tabular-nums;
   font-size: 1rem;
@@ -608,11 +676,37 @@ body {
   color: #fde68a;
   text-shadow: 0 0 4px rgba(251, 191, 36, 0.55);
   white-space: nowrap;
+  opacity: 0;
+  transition: opacity 240ms ease-out;
+}
+.catchup-card-count[data-visible="true"] {
+  opacity: 1;
+  transition: opacity 320ms ease-out 80ms;
+}
+.catchup-card-count-sep {
+  color: rgba(255, 220, 150, 0.32);
+  font-size: 0.625rem;
+}
+.catchup-card-count-value {
+  /* Bracketed LED-readout feel — small ticks frame the number like a
+     handheld game's count window. */
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.1875rem;
+  padding: 0.0625rem 0.25rem;
+  border: 1px solid rgba(251, 191, 36, 0.32);
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.55);
+  box-shadow: inset 0 0 4px rgba(251, 191, 36, 0.10);
 }
 
 /* Pitcher stat line — sits below the matchup row inside the same
    scoreboard inset. Dim, monospaced, low-contrast so it reads as
-   "stat ribbon under the matchup" not as a second header line. */
+   "stat ribbon under the matchup" not as a second header line. Gated
+   behind settle for the same reason the count is: the upstream value
+   is the pitcher's line AFTER this play resolves, so revealing it
+   mid-flight inverts the timing (e.g. 2.0 IP shown while only 2 outs
+   are lit on the dots). */
 .catchup-card-pitcher-line {
   margin: 0;
   padding: 0.125rem 0.5rem 0;
@@ -623,18 +717,39 @@ body {
   letter-spacing: 0.10em;
   color: rgba(255, 220, 150, 0.62);
   text-align: center;
+  opacity: 0;
+  transition: opacity 240ms ease-out;
+}
+.catchup-card-pitcher-line[data-visible="true"] {
+  opacity: 1;
+  transition: opacity 360ms ease-out 120ms;
 }
 
-/* ── Outs dots — three LED bulbs in the situation rail ─── */
+/* ── Outs dots — three LED bulbs in the situation rail ───
+   Chunky recessed-bezel window with the same dot-matrix scanlines as
+   the rest of the LCD glass, so the dots read as "lit segments inside
+   the screen" rather than "round pills sitting on top of UI". */
 .outs-dots {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.4375rem;
   padding: 0.1875rem 0.5rem;
-  border: 1px solid rgba(251, 191, 36, 0.32);
-  border-radius: 0.3125rem;
-  background: rgba(0, 0, 0, 0.55);
-  box-shadow: inset 0 0 6px rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.42);
+  border-radius: 2px;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.02) 0px,
+      rgba(255, 255, 255, 0.02) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    rgba(0, 0, 0, 0.65);
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.55),
+    inset 0 1px 2px rgba(0, 0, 0, 0.55),
+    inset 0 0 6px rgba(251, 191, 36, 0.10);
 }
 .outs-dots-label {
   margin-left: 0.1875rem;
@@ -701,16 +816,31 @@ body {
 }
 
 .catchup-card-score {
+  /* Score window — chunky LED-bezel feel. Double border (outer amber
+     trace + inner black inset shadow) gives the "deep recessed display"
+     character of a Mattel handheld score window. Dot-matrix scanlines
+     bleed under the digits so the LCD glass continues across the panel. */
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 0.625rem;
   padding: 0.25rem 0.625rem 0.25rem 0.875rem;
-  border: 1px solid rgba(251, 191, 36, 0.45);
-  border-radius: 0.25rem;
-  background: rgba(0, 0, 0, 0.85);
+  border: 1px solid rgba(251, 191, 36, 0.55);
+  border-radius: 2px;
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.02) 0px,
+      rgba(255, 255, 255, 0.02) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    rgba(0, 0, 0, 0.88);
   box-shadow:
-    inset 0 0 0 1px rgba(0, 0, 0, 0.6),
-    inset 0 0 8px rgba(251, 191, 36, 0.08);
+    inset 0 0 0 1px rgba(0, 0, 0, 0.7),
+    inset 0 1px 2px rgba(0, 0, 0, 0.65),
+    inset 0 0 10px rgba(251, 191, 36, 0.12),
+    0 0 0 1px rgba(0, 0, 0, 0.6);
   font-family: var(--font-pixel-mono), ui-monospace, "SF Mono", "Menlo", "Monaco", monospace;
 }
 .catchup-card-score-line {
@@ -814,9 +944,12 @@ body {
 }
 
 /* Result LED strip — same inset-screen vocabulary as the scoreboard,
-   but stretched into a thin amber-edged display under the field. */
+   but stretched into a thin amber-edged display under the field. Inherits
+   the same dot-matrix scanlines as the top header so all three readouts
+   (header / chip / narration) read as the same LCD glass. */
 .catchup-result-chip {
   align-self: stretch;
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -828,6 +961,20 @@ body {
   border: 1px solid var(--device-border);
   border-radius: var(--device-radius-screen);
   background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.018) 0px,
+      rgba(255, 255, 255, 0.018) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    repeating-linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.012) 0px,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
     linear-gradient(180deg, var(--device-screen-deep) 0%, var(--device-screen) 100%);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.65),
@@ -981,7 +1128,22 @@ body {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--device-border-soft);
   border-radius: var(--device-radius-screen);
-  background: var(--device-screen);
+  background:
+    repeating-linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.018) 0px,
+      rgba(255, 255, 255, 0.018) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    repeating-linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.012) 0px,
+      rgba(255, 255, 255, 0.012) 1px,
+      transparent 1px,
+      transparent 2px
+    ),
+    var(--device-screen);
   box-shadow:
     inset 0 1px 0 rgba(0, 0, 0, 0.5),
     inset 0 0 10px rgba(0, 0, 0, 0.45);

--- a/web/src/components/catchup/BaseballLightField.tsx
+++ b/web/src/components/catchup/BaseballLightField.tsx
@@ -6,7 +6,6 @@ import type {
   BaseballBaseState,
   PlayAnimationProfile,
   PlayEventType,
-  RunnerNames,
 } from "@/lib/types";
 import {
   FIELDER_POS,
@@ -38,14 +37,14 @@ import { buildTrajectory } from "@/lib/trajectory";
 
 interface BaseballLightFieldProps {
   /** Optional snapshot of the previously-displayed card's ENDING state.
-   *  When supplied, the field renders bulbs/labels for `prior` initially,
-   *  then crosses into `before` during the card's bridge phase. */
+   *  When supplied, the field renders base-occupancy bulbs for `prior`
+   *  initially, then crosses into `before` during the card's bridge
+   *  phase. Per-base runner NAMES are intentionally not rendered on the
+   *  field — the only place names appear is the scoreboard's matchup
+   *  row above. */
   baseStatePrior?: BaseballBaseState;
-  runnerNamesPrior?: RunnerNames;
   baseStateBefore: BaseballBaseState;
   baseStateAfter?: BaseballBaseState;
-  runnerNamesBefore?: RunnerNames;
-  runnerNamesAfter?: RunnerNames;
   /** Animation plan — path + timing per runner. Required for runner dots. */
   runnerMovements?: RunnerMovement[];
   ballPath?: BallPath;
@@ -53,8 +52,6 @@ interface BaseballLightFieldProps {
   animationProfile?: PlayAnimationProfile;
   scoreBefore?: { home: number; away: number };
   scoreAfter?: { home: number; away: number };
-  /** Last name (or short label) of the batter at home plate. */
-  batterLabel?: string;
   /** ms after mount when the runners phase starts — used to offset SMIL
    *  begin times. Comes from CatchupCard's milestones.runners. */
   runnersBeginMs?: number;
@@ -348,18 +345,14 @@ function hasDefensiveThrowContext(
 
 export function BaseballLightField({
   baseStatePrior,
-  runnerNamesPrior,
   baseStateBefore,
   baseStateAfter,
-  runnerNamesBefore,
-  runnerNamesAfter,
   runnerMovements,
   ballPath = "pitch",
   eventType = "other",
   animationProfile = "other",
   scoreBefore,
   scoreAfter,
-  batterLabel,
   runnersBeginMs,
   accentColor = "#5a8ac6",
   isActive,
@@ -668,47 +661,14 @@ export function BaseballLightField({
         <BaseShape pos={POS.second} />
         <BaseShape pos={POS.third} />
 
-        {/* Base bulbs — lifecycle drives the cross-fade. */}
+        {/* Base-occupancy markers — show a clear lit "runner here" dot
+            for each occupied bag. Names live in the scoreboard above
+            (BATTER vs PITCHER), never on the field, so the field stays
+            clean and the eye doesn't have to read four floating name
+            labels during the play. */}
         <BaseBulb pos={POS.first}  base="first"  prior={baseStatePrior?.first}  before={baseStateBefore.first}  after={after.first}  />
         <BaseBulb pos={POS.second} base="second" prior={baseStatePrior?.second} before={baseStateBefore.second} after={after.second} />
         <BaseBulb pos={POS.third}  base="third"  prior={baseStatePrior?.third}  before={baseStateBefore.third}  after={after.third}  />
-
-        {/* Runner-name labels. Prior/pre/post triple handles the bridge +
-            play cross-fade. When the base IS occupied but the name is
-            missing (upstream gap), a placeholder is rendered so the
-            runner is never invisible — the bulb + label always agree on
-            "someone is here." */}
-        <BaseLabel anchor="first"
-          prior={runnerLabel(baseStatePrior?.first, runnerNamesPrior?.first)}
-          before={runnerLabel(baseStateBefore.first, runnerNamesBefore?.first)}
-          after={runnerLabel(after.first, runnerNamesAfter?.first)}
-        />
-        <BaseLabel anchor="second"
-          prior={runnerLabel(baseStatePrior?.second, runnerNamesPrior?.second)}
-          before={runnerLabel(baseStateBefore.second, runnerNamesBefore?.second)}
-          after={runnerLabel(after.second, runnerNamesAfter?.second)}
-        />
-        <BaseLabel anchor="third"
-          prior={runnerLabel(baseStatePrior?.third, runnerNamesPrior?.third)}
-          before={runnerLabel(baseStateBefore.third, runnerNamesBefore?.third)}
-          after={runnerLabel(after.third, runnerNamesAfter?.third)}
-        />
-
-        {batterLabel && (() => {
-          const upper = batterLabel.trim().toUpperCase();
-          return (
-            <text
-              className="field-batter-label"
-              x={POS.home.x}
-              y={POS.home.y + 22}
-              textAnchor="middle"
-              fontSize={labelFontSize(upper)}
-              fontWeight="700"
-            >
-              {upper}
-            </text>
-          );
-        })()}
 
         {showContact && (
           <circle
@@ -857,124 +817,6 @@ export function BaseballLightField({
 
 // ── Sub-components ────────────────────────────────────────
 
-/**
- * Resolve the label that should appear at a base given (state, name).
- *
- * Three cases:
- *   - base empty                        → `undefined` (no label, no bulb)
- *   - base occupied + name known        → the name itself
- *   - base occupied + name missing      → "ON BASE" placeholder so the
- *                                          bulb is never orphaned
- *
- * Upstream backend gaps (a `runner_names` map that doesn't list a base
- * the `base_state` says is occupied) used to render a lit bulb with no
- * label — visually reads as "ghost runner." The placeholder restores
- * the runner's existence.
- */
-function runnerLabel(occupied: boolean | undefined, name: string | undefined): string | undefined {
-  if (!occupied) return undefined;
-  const trimmed = name?.trim();
-  if (trimmed) return trimmed;
-  return "ON BASE";
-}
-
-function BaseLabel({
-  anchor,
-  prior,
-  before,
-  after,
-}: {
-  anchor: "first" | "second" | "third";
-  prior?: string;
-  before?: string;
-  after?: string;
-}) {
-  if (!prior && !before && !after) return null;
-  const priorLabel = prior ? prior.trim() : null;
-  const beforeLabel = before ? before.trim() : null;
-  const afterLabel = after ? after.trim() : null;
-  // No state change at all — just render the persistent label.
-  if (
-    priorLabel === beforeLabel &&
-    beforeLabel === afterLabel &&
-    afterLabel
-  ) {
-    return <BaseLabelText anchor={anchor} text={afterLabel} lifecycle="both" />;
-  }
-  // No bridge change, only play change — keep the existing pre/post pair.
-  if (priorLabel === beforeLabel || !priorLabel) {
-    if (beforeLabel && afterLabel && beforeLabel === afterLabel) {
-      return <BaseLabelText anchor={anchor} text={afterLabel} lifecycle="both" />;
-    }
-    return (
-      <>
-        {beforeLabel && (
-          <BaseLabelText anchor={anchor} text={beforeLabel} lifecycle="pre" />
-        )}
-        {afterLabel && (
-          <BaseLabelText anchor={anchor} text={afterLabel} lifecycle="post" />
-        )}
-      </>
-    );
-  }
-  // Bridge change is real — render up to three labels keyed by lifecycle.
-  return (
-    <>
-      {priorLabel && (
-        <BaseLabelText anchor={anchor} text={priorLabel} lifecycle="prior" />
-      )}
-      {beforeLabel && (
-        <BaseLabelText anchor={anchor} text={beforeLabel} lifecycle="pre" />
-      )}
-      {afterLabel && beforeLabel !== afterLabel && (
-        <BaseLabelText anchor={anchor} text={afterLabel} lifecycle="post" />
-      )}
-    </>
-  );
-}
-
-function BaseLabelText({
-  anchor,
-  text,
-  lifecycle,
-}: {
-  anchor: "first" | "second" | "third";
-  text: string;
-  lifecycle: "prior" | "pre" | "post" | "both";
-}) {
-  const placement: Record<typeof anchor, { x: number; y: number; align: "start" | "middle" | "end" }> = {
-    first:  { x: POS.first.x  + 14, y: POS.first.y  + 4,  align: "start"  },
-    second: { x: POS.second.x,      y: POS.second.y - 14, align: "middle" },
-    third:  { x: POS.third.x  - 14, y: POS.third.y  + 4,  align: "end"    },
-  };
-  const p = placement[anchor];
-  const upper = text.toUpperCase();
-  return (
-    <text
-      className="field-base-label"
-      data-lifecycle={lifecycle}
-      x={p.x}
-      y={p.y}
-      textAnchor={p.align}
-      fontSize={labelFontSize(upper)}
-      fontWeight="700"
-    >
-      {upper}
-    </text>
-  );
-}
-
-/** Per-label font size — shrinks for long full names so we never need to
- *  truncate. Calibrated for first-and-last MLB names ("AARON JUDGE",
- *  "VLADIMIR GUERRERO JR.", "ORLANDO ARCIA") in the 320 viewBox. */
-function labelFontSize(text: string): number {
-  if (text.length <= 8) return 8.5;
-  if (text.length <= 12) return 7.5;
-  if (text.length <= 16) return 6.5;
-  if (text.length <= 20) return 5.6;
-  return 5;
-}
-
 function BaseShape({ pos }: { pos: { x: number; y: number } }) {
   // Solid white square rotated 45° — the white-diamond base markers
   // from the Mattel reference. Pure fill, no stroke; pops cleanly
@@ -1026,17 +868,20 @@ function BaseBulb({
   else if (!before && after) lifecycle = "post";
   else lifecycle = "post";
 
+  // Two-circle marker: a team-accent disc with a chunky cream rim. Sits
+  // right on top of the white base diamond, so an occupied base reads as
+  // a clearly distinct shape from an empty base at a glance — which the
+  // single small accent dot wasn't doing on the green grass.
   return (
-    <circle
+    <g
       className="field-base-bulb"
-      cx={pos.x}
-      cy={pos.y}
-      r={4}
-      fill="var(--field-accent)"
       data-testid="base-bulb"
       data-base={base}
       data-lifecycle={lifecycle}
-    />
+    >
+      <circle cx={pos.x} cy={pos.y} r={6.5} fill="#f5efdc" />
+      <circle cx={pos.x} cy={pos.y} r={4.5} fill="var(--field-accent)" />
+    </g>
   );
 }
 

--- a/web/src/components/catchup/BaseballLightField.tsx
+++ b/web/src/components/catchup/BaseballLightField.tsx
@@ -13,7 +13,9 @@ import {
   FIELD_POINTS,
   FOUL_LEFT,
   FOUL_RIGHT,
-  WALL_SEGMENTS,
+  HOME_TO_MOUND_DIRT_WIDTH,
+  INFIELD_DIRT_RADIUS,
+  WALL_RADIUS,
 } from "@/lib/field-geometry";
 import { basepathLength, basepathSvgPath, type RunnerMovement } from "@/lib/runner-paths";
 import type { RunnerMovementStyle } from "@/lib/types";
@@ -469,11 +471,15 @@ export function BaseballLightField({
         shapeRendering="geometricPrecision"
         aria-hidden="true"
       >
-        {/* Vector-monitor grammar: black background, amber line work, no
-            painted fills. Every visible element is either a stroke or a
-            single solid dot — nothing is gradient-textured. The only
-            gradient remaining is the home-run afterglow halo, which is
-            scoped to the HR event. */}
+        {/* Mattel-handheld grammar: a single kelly-green fair-territory
+            pentagon with a black dirt zone over the mound + the alley to
+            home, white-filled bases and home plate, white foul lines.
+            No basepath chalk runs between 1B↔2B or 2B↔3B — those are
+            dirt on a real diamond and were reading as a UI border on
+            the field. The defs block keeps the ball-glow filter and the
+            home-run afterglow gradient; the analog wobble filter is
+            also retained so the white foul lines pick up a faint
+            phosphor jitter. */}
         <defs>
           <radialGradient id="field-homer-glow" cx="50%" cy="40%" r="60%">
             <stop offset="0%"   stopColor="rgba(251, 191, 36, 0.45)" />
@@ -536,10 +542,50 @@ export function BaseballLightField({
           )}
         </defs>
 
-        {/* Foul lines + basepath wireframe travel through the displacement
-            filter when the card is active so their long straight runs pick
-            up faint analog wobble. The wall segments, mound, runner dots,
-            ball, and bases stay crisp. */}
+        {/* ── Fair-territory grass — kelly-green fan ─────────
+            One single green fill spans the whole fair-territory
+            pentagon: home → foul-left wall point → outer arc →
+            foul-right wall point → home. Sits at the bottom of the
+            paint stack so every white line, dirt patch, base, and
+            moving object lands on top of it. */}
+        <path
+          className="field-grass"
+          d={`M${POS.home.x},${POS.home.y}
+              L${FOUL_LEFT.x},${FOUL_LEFT.y}
+              A${WALL_RADIUS},${WALL_RADIUS} 0 0 1 ${FOUL_RIGHT.x},${FOUL_RIGHT.y} Z`}
+        />
+
+        {/* ── Infield dirt — black mound + home-to-mound alley ──
+            On the Mattel reference the dirt is solid black: a round
+            mound zone in the middle of the green, with a narrow
+            vertical strip running down to home plate. We mirror that
+            with two filled shapes — the rectangle is centered on the
+            x-axis between home and mound, the circle is centered on
+            the mound itself. The two overlap so they fuse into one
+            continuous black shape. */}
+        <rect
+          className="field-dirt"
+          x={POS.home.x - HOME_TO_MOUND_DIRT_WIDTH / 2}
+          y={POS.mound.y}
+          width={HOME_TO_MOUND_DIRT_WIDTH}
+          height={POS.home.y - POS.mound.y}
+        />
+        <circle
+          className="field-dirt"
+          cx={POS.mound.x}
+          cy={POS.mound.y}
+          r={INFIELD_DIRT_RADIUS}
+        />
+
+        {/* ── Foul lines — the only field-chalk strokes ─────
+            Home → 1B wall and home → 3B wall. These pass exactly
+            through 1B and 3B by construction (see field-geometry).
+            The basepath chalk between 1B↔2B and 2B↔3B is intentionally
+            absent — those segments are dirt on a real diamond, and the
+            old amber diamond outline was reading as a futuristic UI
+            border. The displacement filter gives the long straight
+            runs a hair of phosphor jitter so they don't read as a
+            vector tool's geometric output. */}
         <g filter={isActive ? "url(#field-displace-subtle)" : undefined}>
           <line
             x1={POS.home.x}
@@ -547,8 +593,8 @@ export function BaseballLightField({
             x2={FOUL_LEFT.x}
             y2={FOUL_LEFT.y}
             className="field-foul-line"
-            stroke="rgba(255, 207, 64, 0.95)"
-            strokeWidth="2"
+            stroke="#f5efdc"
+            strokeWidth="2.4"
             strokeLinecap="square"
             style={{ animationDelay: "0ms" }}
           />
@@ -558,66 +604,52 @@ export function BaseballLightField({
             x2={FOUL_RIGHT.x}
             y2={FOUL_RIGHT.y}
             className="field-foul-line"
-            stroke="rgba(255, 207, 64, 0.95)"
-            strokeWidth="2"
+            stroke="#f5efdc"
+            strokeWidth="2.4"
             strokeLinecap="square"
             style={{ animationDelay: "1700ms" }}
           />
-          <path
-            d={`M${POS.home.x},${POS.home.y}
-                L${POS.first.x},${POS.first.y}
-                L${POS.second.x},${POS.second.y}
-                L${POS.third.x},${POS.third.y} Z`}
-            fill="none"
-            stroke="rgba(255, 207, 64, 0.98)"
-            strokeWidth="2.5"
-            strokeLinejoin="miter"
-          />
         </g>
 
-        {/* Outfield wall — segmented chunks. Sharper, brighter, square caps.
-            Per-segment animation-delay spreads the phosphor flicker so no
-            two adjacent segments peak or trough together. */}
-        {WALL_SEGMENTS.map((s, i) => (
-          <line
-            key={i}
-            x1={s.x1}
-            y1={s.y1}
-            x2={s.x2}
-            y2={s.y2}
-            className="field-wall-segment"
-            stroke="rgba(255, 207, 64, 1)"
-            strokeWidth="3"
-            strokeLinecap="square"
-            style={{
-              animationDelay: `${(i * 370 + (i % 3) * 130) % 2800}ms`,
-            }}
-          />
-        ))}
-
-        {/* Pitcher's mound — single solid amber dot. The dirt ring is
-            removed; the mound is purely symbolic. */}
-        <circle
-          className="field-mound-dot"
-          cx={POS.mound.x}
-          cy={POS.mound.y}
-          r="3.5"
-          fill="rgba(255, 215, 80, 1)"
+        {/* ── Outfield wall edge — single thin white arc ────
+            Replaces the old segmented amber wall. One smooth white
+            curve from foul-left to foul-right at the outer radius —
+            reads as the painted-on warning track boundary you see on
+            the Mattel field, not as a row of electric segments. */}
+        <path
+          className="field-wall"
+          d={`M${FOUL_LEFT.x},${FOUL_LEFT.y}
+              A${WALL_RADIUS},${WALL_RADIUS} 0 0 1 ${FOUL_RIGHT.x},${FOUL_RIGHT.y}`}
+          fill="none"
+          stroke="#f5efdc"
+          strokeWidth="1.6"
+          strokeLinecap="round"
         />
 
-        {/* Home plate — wireframe pentagon, no fill. The flat edge faces
-            the pitcher (up); the back point faces the catcher (down).
-            In SVG y grows downward, so the point is at home.y + 12. */}
+        {/* Pitcher's rubber — small white pixel on the dirt mound. */}
+        <rect
+          className="field-mound-rubber"
+          x={POS.mound.x - 4}
+          y={POS.mound.y - 1.25}
+          width={8}
+          height={2.5}
+          fill="#f5efdc"
+        />
+
+        {/* Home plate — solid white pentagon. Flat edge faces the
+            pitcher (up); back point faces the catcher (down). In SVG y
+            grows downward, so the point is at home.y + 12. Pure fill
+            so the plate reads as the painted-on Mattel pentagon, not a
+            wireframe glyph. */}
         <path
+          className="field-home-plate"
           d={`M${POS.home.x - 9},${POS.home.y - 5}
               L${POS.home.x + 9},${POS.home.y - 5}
               L${POS.home.x + 11},${POS.home.y + 3}
               L${POS.home.x},${POS.home.y + 12}
               L${POS.home.x - 11},${POS.home.y + 3} Z`}
-          fill="none"
-          stroke="rgba(255, 215, 80, 1)"
-          strokeWidth="2"
-          strokeLinejoin="miter"
+          fill="#f5efdc"
+          stroke="none"
         />
 
         {isRunScoring && (
@@ -944,19 +976,18 @@ function labelFontSize(text: string): number {
 }
 
 function BaseShape({ pos }: { pos: { x: number; y: number } }) {
-  // Wireframe square rotated 45° so it reads as a baseball diamond base.
-  // No fill — just a sharp amber outline so it sits over the basepath
-  // line as a discrete vector glyph.
+  // Solid white square rotated 45° — the white-diamond base markers
+  // from the Mattel reference. Pure fill, no stroke; pops cleanly
+  // against the kelly-green grass without needing an outline.
   return (
     <g transform={`translate(${pos.x} ${pos.y}) rotate(45)`}>
       <rect
-        x={-7}
-        y={-7}
-        width={14}
-        height={14}
-        fill="none"
-        stroke="rgba(255, 215, 80, 0.95)"
-        strokeWidth={1.75}
+        x={-6}
+        y={-6}
+        width={12}
+        height={12}
+        fill="#f5efdc"
+        stroke="none"
         shapeRendering="crispEdges"
       />
     </g>
@@ -1000,8 +1031,8 @@ function BaseBulb({
       className="field-base-bulb"
       cx={pos.x}
       cy={pos.y}
-      r={6}
-      fill="#fbbf24"
+      r={4}
+      fill="var(--field-accent)"
       data-testid="base-bulb"
       data-base={base}
       data-lifecycle={lifecycle}

--- a/web/src/components/catchup/CatchupCard.tsx
+++ b/web/src/components/catchup/CatchupCard.tsx
@@ -294,11 +294,8 @@ export const CatchupCard = forwardRef<HTMLDivElement, CatchupCardProps>(function
         <BaseballLightField
           key={runId}
           baseStatePrior={hasMeaningfulBridge ? priorAfter?.baseState : undefined}
-          runnerNamesPrior={hasMeaningfulBridge ? priorAfter?.runnerNames : undefined}
           baseStateBefore={baseStateBefore}
           baseStateAfter={baseStateAfter}
-          runnerNamesBefore={card.runnerNamesBefore}
-          runnerNamesAfter={card.runnerNamesAfter}
           runnerMovements={movements}
           runnersBeginMs={milestones.runners}
           ballPath={card.ballPath}
@@ -306,7 +303,6 @@ export const CatchupCard = forwardRef<HTMLDivElement, CatchupCardProps>(function
           animationProfile={card.animationProfile}
           scoreBefore={card.scoreBefore}
           scoreAfter={card.scoreAfter}
-          batterLabel={situation.batterName}
           accentColor={accent}
           isActive={isActive}
         />

--- a/web/src/components/catchup/CatchupCard.tsx
+++ b/web/src/components/catchup/CatchupCard.tsx
@@ -262,15 +262,29 @@ export const CatchupCard = forwardRef<HTMLDivElement, CatchupCardProps>(function
               </span>
             )}
             {hasCount && (
-              <span className="catchup-card-count">
-                {(situation.batterName || situation.pitcherName) ? "· " : ""}{situation.balls}-{situation.strikes}
+              <span
+                className="catchup-card-count"
+                data-visible={showAfter ? "true" : "false"}
+                aria-hidden={!showAfter}
+              >
+                {(situation.batterName || situation.pitcherName) && (
+                  <span className="catchup-card-count-sep" aria-hidden>·</span>
+                )}
+                <span className="catchup-card-count-value">
+                  {situation.balls}-{situation.strikes}
+                </span>
               </span>
             )}
           </div>
         )}
 
         {situation.pitcherStatLine && (
-          <p className="catchup-card-pitcher-line" data-testid="pitcher-stat-line">
+          <p
+            className="catchup-card-pitcher-line"
+            data-testid="pitcher-stat-line"
+            data-visible={showAfter ? "true" : "false"}
+            aria-hidden={!showAfter}
+          >
             {situation.pitcherStatLine}
           </p>
         )}

--- a/web/src/components/home/GameRow.tsx
+++ b/web/src/components/home/GameRow.tsx
@@ -42,8 +42,8 @@ export function GameRow({ game, featured = false, completed = false, inProgress 
         : "Reconstruct";
 
   const teamNameClass = featured
-    ? "text-base font-semibold text-[#f5f1e8]"
-    : "text-sm font-medium text-[#f5f1e8]";
+    ? "text-base font-semibold text-[color:var(--home-team-text)]"
+    : "text-sm font-medium text-[color:var(--home-team-text)]";
 
   const inner = (
     <>
@@ -63,7 +63,7 @@ export function GameRow({ game, featured = false, completed = false, inProgress 
               {away?.name ?? game.awayTeam}
             </span>
           </div>
-          <span className="text-[rgba(245,181,54,0.30)]">@</span>
+          <span className="text-[color:var(--home-sep-color)]">@</span>
           <div className="flex items-center gap-1.5">
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
@@ -85,8 +85,8 @@ export function GameRow({ game, featured = false, completed = false, inProgress 
             status.tone === "live"
               ? "shrink-0 inline-flex items-center gap-1 rounded-full border border-red-500/40 bg-red-500/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-red-400"
               : status.tone === "final"
-                ? "shrink-0 rounded-sm border border-[rgba(245,181,54,0.22)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[#9b7626]"
-                : "shrink-0 rounded-sm border border-[rgba(245,181,54,0.16)] px-2 py-0.5 text-[10px] font-medium text-[#9b7626]"
+                ? "shrink-0 rounded-sm border border-[color:var(--home-badge-border)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-[color:var(--home-badge-text)]"
+                : "shrink-0 rounded-sm border border-[color:var(--home-badge-border-soft)] px-2 py-0.5 text-[10px] font-medium text-[color:var(--home-badge-text)]"
           }
         >
           {status.tone === "live" && (
@@ -97,17 +97,17 @@ export function GameRow({ game, featured = false, completed = false, inProgress 
       </div>
 
       <div className="mt-2 flex items-center justify-between">
-        <span className="text-xs text-neutral-500">
+        <span className="text-xs text-[color:var(--home-badge-text)]">
           {formatDate(game.gameDate)}
         </span>
         {!pregame && (
           <span
             className={
               featured
-                ? "inline-flex items-center gap-1 rounded-md border border-[rgba(246,196,83,0.38)] bg-[rgba(246,196,83,0.12)] px-3 py-1.5 text-xs font-semibold text-[#f6c453]"
+                ? "inline-flex items-center gap-1 rounded-md border border-[color:var(--home-cta-border)] bg-[color:var(--home-cta-bg)] px-3 py-1.5 text-xs font-semibold text-[color:var(--home-cta-color)]"
                 : completed
-                  ? "text-xs text-neutral-500"
-                  : "text-xs font-medium text-[#f6c453] inline-flex items-center gap-1"
+                  ? "text-xs text-[color:var(--home-badge-text)]"
+                  : "text-xs font-medium text-[color:var(--home-cta-color)] inline-flex items-center gap-1"
             }
           >
             {cta}
@@ -132,8 +132,8 @@ export function GameRow({ game, featured = false, completed = false, inProgress 
   );
 
   const className = featured
-    ? "block rounded-lg border border-[rgba(245,181,54,0.32)] [background:linear-gradient(180deg,#1d1f24_0%,#15161a_100%)] px-5 py-5 transition hover:border-[rgba(245,181,54,0.50)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_4px_16px_rgba(0,0,0,0.45)]"
-    : "block rounded-lg border border-[rgba(245,181,54,0.14)] bg-[#13141a] px-4 py-3 transition hover:border-[rgba(245,181,54,0.28)]";
+    ? "block rounded-lg border border-[color:var(--home-card-border-featured)] [background:var(--home-grad-featured)] px-5 py-5 transition hover:border-[color:var(--home-card-border-featured-hover)] shadow-[inset_0_1px_0_rgba(255,255,255,0.04),0_4px_16px_rgba(0,0,0,0.45)]"
+    : "block rounded-lg border border-[color:var(--home-card-border)] bg-[color:var(--home-card-bg)] px-4 py-3 transition hover:border-[color:var(--home-card-border-hover)]";
 
   if (pregame) {
     return (

--- a/web/src/components/home/HomePageClient.tsx
+++ b/web/src/components/home/HomePageClient.tsx
@@ -81,10 +81,10 @@ export default function HomePageClient() {
     return (
       <div className="home-deck-page">
         <div className="mx-auto max-w-2xl px-4 py-12 text-center space-y-4">
-          <p className="text-sm text-neutral-400">We couldn&rsquo;t load today&rsquo;s games.</p>
+          <p className="text-sm text-[rgba(245,239,220,0.65)]">We couldn&rsquo;t load today&rsquo;s games.</p>
           <button
             onClick={() => refetch()}
-            className="rounded-lg bg-neutral-800 px-4 py-2 text-sm font-medium text-neutral-100 hover:bg-neutral-700 min-h-[44px]"
+            className="rounded-lg border border-[rgba(245,239,220,0.18)] bg-[#0b110d] px-4 py-2 text-sm font-medium text-[#f5efdc] hover:bg-[#122019] min-h-[44px]"
           >
             Retry
           </button>
@@ -97,8 +97,8 @@ export default function HomePageClient() {
     return (
       <div className="home-deck-page">
         <div data-testid="page-home" className="home-deck mx-auto max-w-2xl px-4 py-16 text-center space-y-3">
-          <h1 className="text-lg font-semibold text-neutral-100">No games in the last 48 hours.</h1>
-          <p className="text-sm text-neutral-400 max-w-sm mx-auto leading-relaxed">
+          <h1 className="text-lg font-semibold text-[#f5efdc]">No games in the last 48 hours.</h1>
+          <p className="text-sm text-[rgba(245,239,220,0.65)] max-w-sm mx-auto leading-relaxed">
             Check back when MLB is on the schedule. During the All-Star break and off-season this view stays empty.
           </p>
         </div>
@@ -112,10 +112,10 @@ export default function HomePageClient() {
     <div className="home-deck-page">
       <div data-testid="page-home" className="home-deck mx-auto max-w-2xl px-4 pt-4 pb-10">
         <header className="mb-6">
-          <h1 className="text-xl font-bold text-neutral-50 tracking-tight">
+          <h1 className="text-xl font-bold text-[#f5efdc] tracking-tight">
             {favTeam ? `${favTeam.name} catch-up` : "Catch up — spoiler-free"}
           </h1>
-          <p className="mt-1 text-sm text-neutral-400 leading-snug">
+          <p className="mt-1 text-sm text-[rgba(245,239,220,0.65)] leading-snug">
             {favTeam
               ? `Start with the ${favTeam.name}, or pick another game below. Scores stay hidden until you reveal.`
               : "MLB games from the last 48 hours. Tap one and walk through the key plays — no scores until the reveal."}
@@ -125,7 +125,7 @@ export default function HomePageClient() {
         {hero && (
           <section aria-label="Hero game" className="mb-6">
             {hero.reason === "fallback" && favTeam && (
-              <p className="mb-2 text-xs text-neutral-500">
+              <p className="mb-2 text-xs text-[rgba(245,239,220,0.55)]">
                 {favTeam.name} aren&rsquo;t playing — here&rsquo;s a recent game instead.
               </p>
             )}

--- a/web/src/components/layout/TopNav.tsx
+++ b/web/src/components/layout/TopNav.tsx
@@ -13,10 +13,10 @@ export function TopNav() {
   return (
     <header
       data-testid="top-nav"
-      className="sticky top-0 z-40 border-b border-neutral-800 bg-neutral-950/80 backdrop-blur"
+      className="sticky top-0 z-40 border-b border-[rgba(245,239,220,0.12)] bg-[#050807]/85 text-[#f5efdc] backdrop-blur"
     >
       <nav className="mx-auto flex h-14 max-w-3xl items-center px-4">
-        <Link href="/" className="flex items-center gap-2.5 min-h-[44px]">
+        <Link href="/" className="flex items-center gap-2.5 min-h-[44px] text-[#f5efdc]">
           <Image
             src="/app-icon.png"
             alt="Scroll Down MLB"
@@ -30,7 +30,7 @@ export function TopNav() {
         <div className="flex-1" />
         <Link
           href="/settings"
-          className="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-full text-neutral-400 hover:text-neutral-50 hover:bg-neutral-800 transition"
+          className="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-full text-[rgba(245,239,220,0.55)] hover:text-[#f5efdc] hover:bg-[rgba(245,239,220,0.06)] transition"
           aria-label="Settings"
           title="Settings"
         >

--- a/web/src/lib/field-geometry.ts
+++ b/web/src/lib/field-geometry.ts
@@ -91,6 +91,20 @@ export const FOUL_LEFT: Point = lineHitsWall({
   y: FIELD_POINTS.third.y - FIELD_POINTS.home.y,
 });
 
+// ── Infield dirt fan ─────────────────────────────────────
+// The black "dirt" zone on the Mattel handheld covers the pitcher's
+// mound area and the alley from home plate up to the mound. We model
+// the dirt as a circle around the mound + a narrow rectangle from home
+// to the mound, both clipped to the fair-territory pentagon by virtue
+// of sitting under the white foul lines.
+export const INFIELD_DIRT_RADIUS = 46;
+
+/** Width of the dirt alley from home plate up to the mound, in viewBox
+ *  units. Sized to feel like the Mattel reference — wide enough to
+ *  read as a deliberate dirt strip, narrow enough that 1B/3B remain
+ *  cleanly on the green side of it. */
+export const HOME_TO_MOUND_DIRT_WIDTH = 22;
+
 /** Wall angle (math-CCW from +x axis) at FOUL_RIGHT — used by anything
  *  that walks the wall arc (segment generator, fielder positioning). */
 export const FOUL_ANGLE_RIGHT = Math.atan2(


### PR DESCRIPTION
This pull request makes significant visual and structural updates to the `BaseballLightField` component, focusing on a major redesign of the field's SVG rendering to more closely match the look of the classic Mattel handheld baseball game. It removes runner name labels from the field, simplifies the prop interface, and updates the field's visual grammar for clarity and authenticity. There are also minor UI improvements to the `CatchupCard` and `GameRow` components for better accessibility and theming.

**BaseballLightField visual and structural redesign:**

- Major overhaul of the SVG field rendering: replaces segmented amber lines and wireframes with solid kelly-green grass, white bases, and a single smooth white outfield wall arc, following the Mattel reference. Infield dirt is now a solid black mound and alley, and foul lines are white with subtle analog wobble. [[1]](diffhunk://#diff-b901c906d27766cc9ee7b0eaf14dc4ba6a81837a8ac432de78cd326bb2fda113L472-R475) [[2]](diffhunk://#diff-b901c906d27766cc9ee7b0eaf14dc4ba6a81837a8ac432de78cd326bb2fda113L539-R590) [[3]](diffhunk://#diff-b901c906d27766cc9ee7b0eaf14dc4ba6a81837a8ac432de78cd326bb2fda113L561-R645)
- Bases are now rendered as solid white diamonds, and base-occupancy markers are two-circle "bulbs" (cream rim with accent core) for clearer visual distinction between occupied and empty bases. [[1]](diffhunk://#diff-b901c906d27766cc9ee7b0eaf14dc4ba6a81837a8ac432de78cd326bb2fda113L828-R832) [[2]](diffhunk://#diff-b901c906d27766cc9ee7b0eaf14dc4ba6a81837a8ac432de78cd326bb2fda113R871-R884)
- Removes runner name labels and batter label from the field entirely; runner names now only appear in the scoreboard, keeping the field visually clean and focused on base occupancy. All related props and helper functions are removed. [[1]](diffhunk://#diff-b901c906d27766cc9ee7b0eaf14dc4ba6a81837a8ac432de78cd326bb2fda113L39-L55) [[2]](diffhunk://#diff-b901c906d27766cc9ee7b0eaf14dc4ba6a81837a8ac432de78cd326bb2fda113L349-L360) [[3]](diffhunk://#diff-b901c906d27766cc9ee7b0eaf14dc4ba6a81837a8ac432de78cd326bb2fda113L639-L680) [[4]](diffhunk://#diff-b901c906d27766cc9ee7b0eaf14dc4ba6a81837a8ac432de78cd326bb2fda113L828-R832) [[5]](diffhunk://#diff-64517c1de6508cf4c56e3e8a253c422e32dceb9a54ef8e5112208b327f51c22eL283-L295)
- Updates import statements and geometry constants to support the new field layout, removing unused constants and adding new ones for dirt and wall geometry.

**UI and accessibility improvements:**

- Updates the `CatchupCard` component to improve accessibility: count and pitcher stat line are now hidden from screen readers until after the play, and the count separator is wrapped for better styling and semantics.
- Adjusts `GameRow` to use CSS variables for team text and separator colors, improving theme consistency and maintainability. [[1]](diffhunk://#diff-36262bbe3234bce7151c2fa06390c3870f044af62a9c522cab0701b585551e5fL45-R46) [[2]](diffhunk://#diff-36262bbe3234bce7151c2fa06390c3870f044af62a9c522cab0701b585551e5fL66-R66)